### PR TITLE
fix(buttons): flatten 3D bevel & align dialog-footer button heights (#265)

### DIFF
--- a/docs/THEMING-GUIDE.md
+++ b/docs/THEMING-GUIDE.md
@@ -175,7 +175,9 @@ All brand style constants are exported from `~/components/ui/buttons`:
 | `brandBg` | `[background-image:var(--brand-bg)]` | Subtle surface background (default on dialogs) |
 | `brandGlow` | `shadow-brand-glow` | Brand glow shadow |
 | `brandToxic` | `bg-gradient-to-br from-violet-700 via-emerald-800 to-emerald-700 hover:from-violet-600 hover:via-emerald-700 hover:to-emerald-600 text-white` | Cyberpunk "toxic ooze" edit affordance — violet-700 → emerald-800 → emerald-700 diagonal blend (same palette family as `brandHighlight`, deeper and smoothly mixed). Used by `<EditButton>` / `<EditIconButton>`. |
-| `brandToxicDepthColors` | `border-b-emerald-900 shadow-emerald-950/60` | 3D depth + shadow tuned to the toxic gradient (deep-emerald glow on press) |
+| `brandToxicGlowLift` | `shadow-emerald-950/60` | Deep-emerald shadow tint for the toxic gradient (`<EditButton>`). |
+| `buttonLift` | `shadow-lg shadow-black/30 transition-all duration-75` | The flat soft-shadow lift shared by every brand button — see [Button Lift](#button-lift-flat). |
+| `brandGlowLift` | `shadow-[0_8px_20px_-8px_var(--glow-violet),inset_0_1px_0_rgba(255,255,255,0.18)]` | Brand-violet glow + inset top highlight for the gradient primary. |
 
 ### Brand Surface Background (`brandBg`)
 
@@ -225,19 +227,27 @@ The `-mx-6 px-6` cancels the dialog's `p-6` for the viewport so the scrollbar si
 
 See [`theming-guide/ai/references/scrollbars-dialogs.md`](theming-guide/ai/references/scrollbars-dialogs.md) for the full ScrollArea-inside-Dialog contract (the `overflow-hidden` rule, why Radix Viewport's `size-full` needs a definite parent height, and how to verify the dialog actually clips).
 
-### 3D Depth Effects
+### Button Lift (Flat)
 
-Buttons support a `depth` prop for 3D press effects:
+Brand buttons are **flat by design** — a soft drop shadow lifts them off the
+dialog surface, and press feedback comes from the base `<Button>`'s
+`active:scale-[0.95]`. The old chunky bevel (`border-b-4` + `active:translate-y`,
+plus per-variant `border-b-<color>` accents) was removed: a footer that mixed
+bevelled and flat buttons read as inconsistent.
 
 ```tsx
-// 3D button (default for PrimaryButton)
+// Flat brand button with a soft-shadow lift (default)
 <PrimaryButton>Create</PrimaryButton>
-
-// Flat button
-<PrimaryButton depth={false}>Create</PrimaryButton>
 ```
 
-The 3D system uses `button3DBase` (shadow, border-b-4, active press) and `button3DDisabled` (muted disabled state).
+The lift lives in `buttonLift` (`shadow-lg shadow-black/30`) and the muted
+disabled treatment in `buttonDisabled`; the gradient primary adds `brandGlowLift`
+(violet glow + inset highlight). The `depth` prop is retained for backwards
+compatibility but only toggles the soft shadow now — there is no bevel.
+
+> **Do not reintroduce 3D bevels.** Never add `border-b-4` /
+> `active:translate-y-*` to a button (inline or via a new constant). Buttons
+> must read consistently flat across a footer — no mix of bevelled and flat.
 
 ### Button Policy
 
@@ -252,19 +262,28 @@ Do **not** use `<Button>` directly for user-facing actions. Reserve `<Button>` f
 
 | Context | Component | Visual |
 |---------|-----------|--------|
-| Main CTA / most-clicked action | `<PrimaryButton>` | Brand gradient + 3D |
-| Form submission | `<SubmitButton>` | Brand gradient + 3D |
-| Dialog confirmation | `<ConfirmButton variant="success">` | Brand gradient + 3D |
-| Destructive dialog action | `<ConfirmButton variant="destructive">` | Red + 3D |
-| Warning dialog action | `<ConfirmButton variant="warning">` | Orange + 3D |
+| Main CTA / most-clicked action | `<PrimaryButton>` | Brand gradient, flat |
+| Form submission | `<SubmitButton>` | Brand gradient, flat |
+| Dialog confirmation | `<ConfirmButton variant="success">` | Brand gradient, flat |
+| Destructive dialog action | `<ConfirmButton variant="destructive">` | Red, flat |
+| Warning dialog action | `<ConfirmButton variant="warning">` | Orange, flat |
 | Supporting/contextual action | `<SecondaryButton>` | Violet gradient + ring |
-| Cancel/back/dismiss | `<SecondaryButton>` or `<CancelButton>` | Translucent violet |
-| Colored contextual action | `<SecondaryButton color="sky">` | Colored background + 3D |
-| Navigation action | `<NavButton>` | Sky blue + 3D |
-| Edit action | `<EditButton>` / `<EditIconButton>` | Toxic violet→emerald cyberpunk blend + 3D |
-| Destructive page action | `<DestructiveButton>` | Red + 3D |
+| Cancel/back/dismiss | `<SecondaryButton>` or `<CancelButton>` | Translucent slate |
+| Colored contextual action | `<SecondaryButton color="sky">` | Colored background, flat |
+| Navigation action | `<NavButton>` | Sky blue, flat |
+| Edit action | `<EditButton>` / `<EditIconButton>` | Toxic violet→emerald cyberpunk blend, flat |
+| Destructive page action | `<DestructiveButton>` | Red, flat |
 
 > `PrimaryButton`, `SubmitButton`, and `ConfirmButton variant="success"` share the brand gradient visual. Choose based on HTML semantics and context, not appearance.
+
+### Footer Button Height
+
+Dialog-footer action buttons are **44px tall** (`min-h-11`) so a row of them
+lines up — a tall button next to short ones is the most common footer
+inconsistency. `ConfirmButton`, `CancelButton`, `SubmitButton`,
+`DestructiveButton`, and `WarningButton` all bake in `min-h-11`. When you build
+a footer, reach for these full-size action buttons (or pass `min-h-11`
+yourself) rather than mixing in a default-height `<Button>`.
 
 ---
 

--- a/docs/THEMING-GUIDE.md
+++ b/docs/THEMING-GUIDE.md
@@ -23,9 +23,8 @@ This theme uses a violet/indigo primary palette with cyan accents for an esports
 Primary CTA buttons use the brand gradient via `<PrimaryButton>`, not flat `bg-primary`. The `--primary` CSS variable remains the base brand color for non-button contexts.
 
 ```tsx
-// Primary CTA (brand gradient + 3D depth)
+// Primary CTA (brand gradient, flat soft-shadow lift)
 <PrimaryButton>Create Tournament</PrimaryButton>
-<PrimaryButton depth={false}>Flat Variant</PrimaryButton>
 
 // Secondary brand action (violet gradient + ring outline)
 <SecondaryButton>Edit Settings</SecondaryButton>
@@ -323,7 +322,7 @@ Renders as a hierarchical breadcrumb with type labels (e.g., "ORGANIZATION" abov
 ### Buttons
 
 ```tsx
-// Primary CTA (brand gradient + 3D depth)
+// Primary CTA (brand gradient, flat soft-shadow lift)
 <PrimaryButton>Create Tournament</PrimaryButton>
 <PrimaryButton size="lg">Large CTA</PrimaryButton>
 
@@ -337,8 +336,8 @@ Renders as a hierarchical breadcrumb with type labels (e.g., "ORGANIZATION" abov
 // Secondary (default brand violet gradient + ring)
 <SecondaryButton>Settings</SecondaryButton>
 
-// Secondary with colored background + 3D
-<SecondaryButton color="cyan" depth>Colored Action</SecondaryButton>
+// Secondary with colored background
+<SecondaryButton color="cyan">Colored Action</SecondaryButton>
 
 // Avoid using <Button> directly for user-facing actions.
 // Reserve for structural uses: dropdown triggers, combobox triggers, etc.

--- a/docs/theming-guide/ai/references/component-substitutions.md
+++ b/docs/theming-guide/ai/references/component-substitutions.md
@@ -1,6 +1,6 @@
 # Component Substitutions
 
-Replace hand-rolled HTML and one-off styled markup with DraftForge's brand component wrappers. The wrappers ship the brand gradient, 3D depth, hover/active states, focus rings, and disabled treatment; raw markup loses all of it and drifts visually over time.
+Replace hand-rolled HTML and one-off styled markup with DraftForge's brand component wrappers. The wrappers ship the brand gradient, soft-shadow lift, consistent height, hover/active states, focus rings, and disabled treatment; raw markup loses all of it and drifts visually over time.
 
 ## Buttons (Primary Targets)
 
@@ -8,15 +8,15 @@ Per [`THEMING-GUIDE.md` §"Button Policy"](../../THEMING-GUIDE.md#button-policy)
 
 | Anti-pattern | Replace with | Notes |
 |---|---|---|
-| `<button onClick={...}>...` | `<PrimaryButton onClick={...}>` | Brand violet→blue gradient + 3D depth. The headline CTA on a view. |
+| `<button onClick={...}>...` | `<PrimaryButton onClick={...}>` | Brand violet→blue gradient, flat soft-shadow lift. The headline CTA on a view. |
 | `<button className="bg-primary ...">` | `<PrimaryButton>` | `bg-primary` flat is reserved for non-button contexts. Buttons use the gradient. |
 | `<Button onClick={submit}>Save</Button>` (form submission) | `<SubmitButton loading={isSubmitting}>Save</SubmitButton>` | Wires `type="submit"` + loading spinner. |
 | `<Button>Confirm</Button>` inside a dialog | `<ConfirmButton variant="success">Approve</ConfirmButton>` | Pairs with `variant="destructive"` / `variant="warning"` for the matching dialog tone. |
 | Supporting / contextual action | `<SecondaryButton>` | Violet gradient + ring outline. "Cancel", "Edit Settings", etc. |
 | Cancel / dismiss inside a dialog | `<CancelButton>` or `<SecondaryButton>` | Translucent violet on opaque backgrounds. |
 | Edit affordance | `<EditButton>` / `<EditIconButton>` | Toxic violet→emerald cyberpunk blend per `brandToxic`. |
-| Destructive page-level action | `<DestructiveButton>` | Red + 3D. NOT for dialog confirmation — use `<ConfirmButton variant="destructive">` there. |
-| Navigation action (link styled as button) | `<NavButton>` | Sky blue + 3D. |
+| Destructive page-level action | `<DestructiveButton>` | Red, flat. NOT for dialog confirmation — use `<ConfirmButton variant="destructive">` there. |
+| Navigation action (link styled as button) | `<NavButton>` | Sky blue, flat. |
 | Icon-only variant of a generic button | The matching `*IconButton` in `buttons/icons/` (e.g. `<EditIconButton>`, `<ViewIconButton>`) | Don't roll a new icon-only button — extend the icons folder. |
 
 ### Structural `<Button>` exceptions (NOT a violation)

--- a/docs/theming-guide/ai/references/grep-recipes.md
+++ b/docs/theming-guide/ai/references/grep-recipes.md
@@ -19,6 +19,9 @@ rg -nB1 -A2 '<Button[^>]*onClick' "$SCOPE" --glob '!**/components/ui/**' \
 rg -n 'from-violet-[0-9]+\s+to-blue-[0-9]+' "$SCOPE" --glob '!**/components/ui/buttons/**'
 rg -nB0 -A0 '<button[^>]*bg-primary|<Button[^>]*bg-primary' "$SCOPE"
 rg -n '<Button[^>]*type=["\x27]submit' "$SCOPE" --glob '!**/components/ui/**'
+
+# Reintroduced 3D bevel — buttons are flat. Any hit is a finding (incl. inside buttons/).
+rg -n 'border-b-4|active:border-b-0|active:translate-y-' frontend/app -g '*.tsx' -g '*.ts'
 ```
 
 ## Avatars

--- a/docs/theming-guide/ai/references/review-checklist.md
+++ b/docs/theming-guide/ai/references/review-checklist.md
@@ -11,7 +11,7 @@ Walk this list against any diff that touches an [in-scope source tree](scope.md)
 - [ ] Page-level destructive action uses `<DestructiveButton>`, not `<ConfirmButton variant="destructive">`.
 - [ ] Edit affordance uses `<EditButton>` / `<EditIconButton>`, not a custom violet button.
 - [ ] Icon-only buttons live in `frontend/app/components/ui/buttons/icons/` (not invented inline).
-- [ ] No 3D bevel on buttons: no `border-b-4` / `active:border-b-0` / `active:translate-y-*` (inline or in a new constant). Buttons are flat. → [3D Depth Effects → Button Lift](../../THEMING-GUIDE.md#button-lift-flat)
+- [ ] No 3D bevel on buttons: no `border-b-4` / `active:border-b-0` / `active:translate-y-*` (inline or in a new constant). Buttons are flat. → [Button Lift](../../THEMING-GUIDE.md#button-lift-flat)
 - [ ] Dialog-footer action buttons are the same height. Use full-size action buttons (`ConfirmButton` / `CancelButton` / `SubmitButton` / `DestructiveButton` / `WarningButton`, all `min-h-11`) — don't mix in a default-height `<Button>`. → [Footer Button Height](../../THEMING-GUIDE.md#footer-button-height)
 - [ ] A "Close"/"dismiss" footer button is neutral (`<CancelButton>` / `<SecondaryButton>`), not red — red reads as a second destructive action next to the real one.
 

--- a/docs/theming-guide/ai/references/review-checklist.md
+++ b/docs/theming-guide/ai/references/review-checklist.md
@@ -11,6 +11,9 @@ Walk this list against any diff that touches an [in-scope source tree](scope.md)
 - [ ] Page-level destructive action uses `<DestructiveButton>`, not `<ConfirmButton variant="destructive">`.
 - [ ] Edit affordance uses `<EditButton>` / `<EditIconButton>`, not a custom violet button.
 - [ ] Icon-only buttons live in `frontend/app/components/ui/buttons/icons/` (not invented inline).
+- [ ] No 3D bevel on buttons: no `border-b-4` / `active:border-b-0` / `active:translate-y-*` (inline or in a new constant). Buttons are flat. → [3D Depth Effects → Button Lift](../../THEMING-GUIDE.md#button-lift-flat)
+- [ ] Dialog-footer action buttons are the same height. Use full-size action buttons (`ConfirmButton` / `CancelButton` / `SubmitButton` / `DestructiveButton` / `WarningButton`, all `min-h-11`) — don't mix in a default-height `<Button>`. → [Footer Button Height](../../THEMING-GUIDE.md#footer-button-height)
+- [ ] A "Close"/"dismiss" footer button is neutral (`<CancelButton>` / `<SecondaryButton>`), not red — red reads as a second destructive action next to the real one.
 
 ## 2. Mandatory Components
 

--- a/docs/theming-guide/ai/references/severity-rubric.md
+++ b/docs/theming-guide/ai/references/severity-rubric.md
@@ -9,7 +9,7 @@ Brand-review findings are graded so reviewers can triage quickly. Use these defi
 User-visible affordance is wrong, accessibility is broken, or the brand contract is violated in a load-bearing way.
 
 Examples:
-- Primary action wired as raw `<button>` (loses brand gradient, 3D depth, focus ring) — should be `<PrimaryButton>`.
+- Primary action wired as raw `<button>` (loses brand gradient, soft-shadow lift, consistent height, focus ring) — should be `<PrimaryButton>`.
 - `<Button onClick={handleSave}>` for a domain action (button policy violation) — should be `<PrimaryButton>` / `<SubmitButton>` / `<ConfirmButton>`.
 - Raw `<img>` rendering a user avatar (skips Discord CDN handling, fallback initials, memoization) — must be `<UserAvatar>`.
 - Manual breadcrumb `<nav>` on a required detail page — must be `<EntityBreadcrumb>`.
@@ -63,7 +63,7 @@ Examples:
 
 ```
 brand: block · frontend/app/routes/tournament/$pk.tsx:84 — raw <button> for "Start Tournament" CTA
-  why: THEMING-GUIDE.md §"Button Policy" — user-facing actions must use a brand wrapper; raw <button> loses gradient, 3D depth, focus ring
+  why: THEMING-GUIDE.md §"Button Policy" — user-facing actions must use a brand wrapper; raw <button> loses gradient, soft-shadow lift, consistent height, focus ring
   fix: replace with <PrimaryButton onClick={handleStart}>Start Tournament</PrimaryButton>
 
 brand: block · frontend/app/features/teams/TeamRoster.tsx:42 — raw <img> for team-captain avatar

--- a/frontend/app/components/events/MmrApprovalModal.tsx
+++ b/frontend/app/components/events/MmrApprovalModal.tsx
@@ -25,8 +25,8 @@ import {
 import { Input } from '~/components/ui/input';
 import { Badge } from '~/components/ui/badge';
 import {
+  CancelButton,
   ConfirmButton,
-  DestructiveButton,
   DotabuffButton,
   SubmitButton,
   brandDialogPanel,
@@ -287,14 +287,14 @@ export function MmrApprovalModal({
               />
 
               <DialogFooter className="flex-col-reverse sm:flex-row gap-2">
-                <DestructiveButton
+                <CancelButton
                   type="button"
                   onClick={() => onOpenChange(false)}
                   disabled={isApproving || isRejecting}
                   data-testid="mmr-modal-close"
                 >
                   Close
-                </DestructiveButton>
+                </CancelButton>
                 {onReject && (
                   <ConfirmButton
                     type="button"

--- a/frontend/app/components/teamdraft/sections/AvailablePlayersSection.tsx
+++ b/frontend/app/components/teamdraft/sections/AvailablePlayersSection.tsx
@@ -7,7 +7,7 @@ import { Input } from '~/components/ui/input';
 import { ScrollArea } from '~/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { cn } from '~/lib/utils';
-import { brandGradient, brandDepthColors } from '~/components/ui/buttons/styles';
+import { brandGradient, brandGlowLift } from '~/components/ui/buttons/styles';
 import { GAME_TYPE } from '~/components/game/constants';
 import { useUserStore } from '~/store/userStore';
 import { useUserCacheStore } from '~/store/userCacheStore';
@@ -340,7 +340,7 @@ export const AvailablePlayersSection = memo(() => {
                   onClick={() => setPositionFilter(pos)}
                   className={cn(
                     "text-xs px-2 py-0.5 h-6",
-                    positionFilter === pos && `${brandGradient} ${brandDepthColors} border-b-2 [text-shadow:_0_1px_2px_rgba(0,0,0,0.5)]`
+                    positionFilter === pos && `${brandGradient} ${brandGlowLift} [text-shadow:_0_1px_2px_rgba(0,0,0,0.5)]`
                   )}
                 >
                   {POSITION_LABELS[pos]}
@@ -359,7 +359,7 @@ export const AvailablePlayersSection = memo(() => {
                   onClick={() => setPickOrderFilter(filter)}
                   className={cn(
                     "text-xs px-2 py-0.5 h-6",
-                    pickOrderFilter === filter && `${brandGradient} ${brandDepthColors} border-b-2 [text-shadow:_0_1px_2px_rgba(0,0,0,0.5)]`
+                    pickOrderFilter === filter && `${brandGradient} ${brandGlowLift} [text-shadow:_0_1px_2px_rgba(0,0,0,0.5)]`
                   )}
                   disabled
                 >
@@ -379,7 +379,7 @@ export const AvailablePlayersSection = memo(() => {
                   onClick={() => setLeagueStatsFilter(filter)}
                   className={cn(
                     "text-xs px-2 py-0.5 h-6",
-                    leagueStatsFilter === filter && `${brandGradient} ${brandDepthColors} border-b-2 [text-shadow:_0_1px_2px_rgba(0,0,0,0.5)]`
+                    leagueStatsFilter === filter && `${brandGradient} ${brandGlowLift} [text-shadow:_0_1px_2px_rgba(0,0,0,0.5)]`
                   )}
                   disabled
                 >

--- a/frontend/app/components/ui/alert-dialog.tsx
+++ b/frontend/app/components/ui/alert-dialog.tsx
@@ -3,7 +3,7 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
 import { cn } from "~/lib/utils"
 import { buttonVariants } from "~/components/ui/button"
-import { brandBg, brandSecondary, button3DVariants } from "~/components/ui/buttons/styles"
+import { brandBg, brandSecondary, brandButtonVariants } from "~/components/ui/buttons/styles"
 
 function AlertDialog({
   ...props
@@ -130,7 +130,7 @@ function AlertDialogAction({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
   return (
     <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), button3DVariants.success, className)}
+      className={cn(buttonVariants(), brandButtonVariants.success, className)}
       {...props}
     />
   )

--- a/frontend/app/components/ui/brand-dropdown-menu.tsx
+++ b/frontend/app/components/ui/brand-dropdown-menu.tsx
@@ -11,13 +11,13 @@ import {
 } from '~/components/ui/dropdown-menu';
 import {
   brandBg,
-  brandDepthColors,
+  brandGlowLift,
   brandErrorBg,
   brandGradient,
   brandLabelOnGradient,
   brandSecondary,
-  button3DBase,
-  button3DDisabled,
+  buttonLift,
+  buttonDisabled,
 } from '~/components/ui/buttons';
 import { cn } from '~/lib/utils';
 
@@ -55,11 +55,11 @@ const variantStyles = {
   destructive: 'text-error font-medium [&_svg]:text-error hover:bg-red-500/20 focus:bg-red-500/20',
 } as const;
 
-// Reuse shared button3D recipes so trigger matches its sibling standalone button at rest.
+// Reuse shared button lift recipes so trigger matches its sibling standalone button at rest.
 const triggerVariants = {
-  primary: `${button3DBase} ${button3DDisabled} ${brandGradient} ${brandDepthColors} ${brandLabelOnGradient} border-0`,
-  secondary: `${button3DBase} ${button3DDisabled} ${brandSecondary} border-b-violet-700/50`,
-  admin: `${button3DBase} ${button3DDisabled} ${brandErrorBg} text-foreground hover:brightness-110 border-b-red-900/60 shadow-red-950/40`,
+  primary: `${buttonLift} ${buttonDisabled} ${brandGradient} ${brandGlowLift} ${brandLabelOnGradient} border-0`,
+  secondary: `${buttonLift} ${buttonDisabled} ${brandSecondary}`,
+  admin: `${buttonLift} ${buttonDisabled} ${brandErrorBg} text-foreground hover:brightness-110 shadow-red-950/40`,
 } as const;
 
 /**

--- a/frontend/app/components/ui/buttons/CancelButton.tsx
+++ b/frontend/app/components/ui/buttons/CancelButton.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
 import { HotkeyBadge } from './HotkeyBadge';
-import { brandNeutralOpaque, brandNeutralOpaque3D, button3DVariants } from './styles';
+import { brandNeutralOpaque, brandNeutralOpaqueLift, brandButtonVariants } from './styles';
 
 export type CancelButtonVariant = 'default' | 'success' | 'destructive';
 
 export interface CancelButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant'> {
-  /** Whether to apply 3D depth effects (default: true) */
+  /** Whether to apply the soft-shadow lift (default: true) */
   depth?: boolean;
   /** Color variant - 'success' for green cancel (e.g., in warning dialogs) */
   variant?: CancelButtonVariant;
@@ -17,7 +17,7 @@ export interface CancelButtonProps
 }
 
 /**
- * A cancel button with outline styling and optional 3D depth effects.
+ * A cancel button with outline styling and an optional soft-shadow lift.
  * Can be wrapped with DialogClose for dialog dismissal.
  *
  * @example
@@ -39,9 +39,9 @@ export interface CancelButtonProps
 const CancelButton = React.forwardRef<HTMLButtonElement, CancelButtonProps>(
   ({ children = 'Cancel', className, depth = true, variant = 'default', hotkey, ...props }, ref) => {
     const variantStyles = {
-      default: depth ? brandNeutralOpaque3D : brandNeutralOpaque,
-      success: depth ? button3DVariants.success : 'bg-green-600 text-white hover:bg-green-500',
-      destructive: depth ? button3DVariants.destructive : 'bg-red-600 text-white hover:bg-red-500',
+      default: depth ? brandNeutralOpaqueLift : brandNeutralOpaque,
+      success: depth ? brandButtonVariants.success : 'bg-green-600 text-white hover:bg-green-500',
+      destructive: depth ? brandButtonVariants.destructive : 'bg-red-600 text-white hover:bg-red-500',
     };
 
     // When hotkey is unset, pass children as the single child so `asChild`

--- a/frontend/app/components/ui/buttons/ConfirmButton.tsx
+++ b/frontend/app/components/ui/buttons/ConfirmButton.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
 import { HotkeyBadge } from './HotkeyBadge';
-import { brandGradient, button3DVariants } from './styles';
+import { brandGradient, brandButtonVariants } from './styles';
 
 export type ConfirmButtonVariant = 'default' | 'destructive' | 'warning' | 'success';
 
@@ -13,14 +13,14 @@ export interface ConfirmButtonProps
   loading?: boolean;
   /** Visual variant */
   variant?: ConfirmButtonVariant;
-  /** Whether to apply 3D depth effects (default: true) */
+  /** Whether to apply the soft-shadow lift (default: true) */
   depth?: boolean;
   /** Optional keyboard shortcut label rendered as a badge in the top-left corner. */
   hotkey?: string;
 }
 
 /**
- * A confirm action button with 3D depth effects for use in dialogs.
+ * A confirm action button with a soft-shadow lift for use in dialogs.
  * Supports multiple variants for different action types.
  *
  * @example
@@ -59,10 +59,10 @@ const ConfirmButton = React.forwardRef<HTMLButtonElement, ConfirmButtonProps>(
     ref
   ) => {
     const variantStyles = {
-      default: depth ? button3DVariants.success : brandGradient,
-      destructive: depth ? button3DVariants.destructive : 'bg-red-600 text-white hover:bg-red-500',
-      warning: depth ? button3DVariants.warning : 'bg-orange-500 text-white hover:bg-orange-400',
-      success: depth ? button3DVariants.success : brandGradient,
+      default: depth ? brandButtonVariants.success : brandGradient,
+      destructive: depth ? brandButtonVariants.destructive : 'bg-red-600 text-white hover:bg-red-500',
+      warning: depth ? brandButtonVariants.warning : 'bg-orange-500 text-white hover:bg-orange-400',
+      success: depth ? brandButtonVariants.success : brandGradient,
     };
 
     const loadingText = {

--- a/frontend/app/components/ui/buttons/DestructiveButton.tsx
+++ b/frontend/app/components/ui/buttons/DestructiveButton.tsx
@@ -3,20 +3,20 @@ import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
 import { HotkeyBadge } from './HotkeyBadge';
-import { brandErrorPrimary, button3DBase, button3DDisabled } from './styles';
+import { brandErrorPrimary, buttonLift, buttonDisabled } from './styles';
 
 export interface DestructiveButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant'> {
   /** Whether the button is in a loading state */
   loading?: boolean;
-  /** Whether to apply 3D depth effects (default: true) */
+  /** Whether to apply the soft-shadow lift (default: true) */
   depth?: boolean;
   /** Optional keyboard shortcut label rendered as a badge in the top-left corner. */
   hotkey?: string;
 }
 
 /**
- * A destructive action button with red styling and 3D depth effects.
+ * A destructive action button with red styling and a soft-shadow lift.
  * Used for delete, remove, or other destructive actions.
  *
  * @example
@@ -48,7 +48,7 @@ const DestructiveButton = React.forwardRef<
       className={cn(
         // min-h-11 matches ConfirmButton/CancelButton so footer rows align.
         'min-h-11',
-        depth ? `${button3DBase} ${button3DDisabled} ${brandErrorPrimary} shadow-red-950/40` : brandErrorPrimary,
+        depth ? `${buttonLift} ${buttonDisabled} ${brandErrorPrimary} shadow-red-950/40` : brandErrorPrimary,
         hotkey && 'relative',
         className
       )}

--- a/frontend/app/components/ui/buttons/DestructiveButton.tsx
+++ b/frontend/app/components/ui/buttons/DestructiveButton.tsx
@@ -46,10 +46,9 @@ const DestructiveButton = React.forwardRef<
       ref={ref}
       disabled={disabled || loading}
       className={cn(
-        // Bottom-border opacity bumped 50 → 80 so the 3D floor reads at the
-        // same visual weight as <EditButton>'s emerald-900 floor. /50 was
-        // making the destructive pill look ~2px shorter than its sibling.
-        depth ? `${button3DBase} ${button3DDisabled} ${brandErrorPrimary} border-b-red-900/80 shadow-red-950/40` : brandErrorPrimary,
+        // min-h-11 matches ConfirmButton/CancelButton so footer rows align.
+        'min-h-11',
+        depth ? `${button3DBase} ${button3DDisabled} ${brandErrorPrimary} shadow-red-950/40` : brandErrorPrimary,
         hotkey && 'relative',
         className
       )}

--- a/frontend/app/components/ui/buttons/EditButton.tsx
+++ b/frontend/app/components/ui/buttons/EditButton.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
-import { brandToxic, button3DVariants } from './styles';
+import { brandToxic, brandButtonVariants } from './styles';
 
 export interface EditButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant'> {
   /** When true, shows "Done Editing" text; when false, shows children or "Edit" */
   editMode?: boolean;
-  /** Whether to apply 3D depth effects (default: true) */
+  /** Whether to apply the soft-shadow lift (default: true) */
   depth?: boolean;
 }
 
 /**
- * An edit button with purple theme styling and 3D depth effects.
+ * An edit button with purple theme styling and a soft-shadow lift.
  * Can toggle between "Edit" and "Done Editing" states.
  *
  * @example
@@ -28,7 +28,7 @@ const EditButton = React.forwardRef<HTMLButtonElement, EditButtonProps>(
       <Button
         ref={ref}
         className={cn(
-          depth ? button3DVariants.edit : brandToxic,
+          depth ? brandButtonVariants.edit : brandToxic,
           className
         )}
         {...props}

--- a/frontend/app/components/ui/buttons/NavButton.tsx
+++ b/frontend/app/components/ui/buttons/NavButton.tsx
@@ -2,7 +2,7 @@ import { ChevronLeft, ChevronRight, ChevronsRight } from 'lucide-react';
 import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
-import { brandDepthColors, brandGradient, button3DBase, button3DDisabled } from './styles';
+import { brandGlowLift, brandGradient, buttonLift, buttonDisabled } from './styles';
 
 export type NavDirection = 'prev' | 'next' | 'latest';
 
@@ -10,7 +10,7 @@ export interface NavButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant'> {
   /** Navigation direction - determines icon and default text */
   direction?: NavDirection;
-  /** Whether to apply 3D depth effects (default: true) */
+  /** Whether to apply the soft-shadow lift (default: true) */
   depth?: boolean;
 }
 
@@ -24,7 +24,7 @@ const directionConfig: Record<
 };
 
 /**
- * A navigation button with sky blue theme styling and 3D depth effects.
+ * A navigation button with sky blue theme styling and a soft-shadow lift.
  * Used for navigation between pages or items.
  *
  * @example
@@ -43,10 +43,10 @@ const NavButton = React.forwardRef<HTMLButtonElement, NavButtonProps>(
       <Button
         ref={ref}
         className={cn(
-          depth && button3DBase,
-          depth && button3DDisabled,
+          depth && buttonLift,
+          depth && buttonDisabled,
           brandGradient,
-          brandDepthColors,
+          brandGlowLift,
           '[text-shadow:_0_1px_2px_rgba(0,0,0,0.5)]',
           '[&_svg]:text-white [&_svg]:drop-shadow-[1px_1px_1px_rgba(0,0,0,0.5)]',
           className

--- a/frontend/app/components/ui/buttons/PrimaryButton.tsx
+++ b/frontend/app/components/ui/buttons/PrimaryButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
-import { brandDepthColors, brandGradient, brandLabelOnGradient, button3DBase, button3DDisabled } from './styles';
+import { brandGlowLift, brandGradient, brandLabelOnGradient, buttonLift, buttonDisabled } from './styles';
 
 export type PrimaryButtonColor = 'green' | 'blue' | 'yellow';
 
@@ -9,14 +9,14 @@ export interface PrimaryButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant'> {
   /** Color theme for the button (omit for brand gradient) */
   color?: PrimaryButtonColor;
-  /** Whether to apply 3D depth effects (default: true) */
+  /** Whether to apply the soft-shadow lift (default: true) */
   depth?: boolean;
 }
 
 const colorClasses: Record<PrimaryButtonColor, string> = {
-  green: 'bg-green-700 hover:bg-green-600 text-white border-b-green-900 shadow-green-900/50',
-  blue: 'bg-blue-700 hover:bg-blue-600 text-white border-b-blue-900 shadow-blue-900/50',
-  yellow: 'bg-yellow-600 hover:bg-yellow-500 text-black border-b-yellow-800 shadow-yellow-900/50',
+  green: 'bg-green-700 hover:bg-green-600 text-white shadow-green-900/50',
+  blue: 'bg-blue-700 hover:bg-blue-600 text-white shadow-blue-900/50',
+  yellow: 'bg-yellow-600 hover:bg-yellow-500 text-black shadow-yellow-900/50',
 };
 
 // Two-layer dark text-shadow under every PrimaryButton label: a hard 1px
@@ -26,7 +26,7 @@ const colorClasses: Record<PrimaryButtonColor, string> = {
 const primaryTextStroke =
   '[text-shadow:_0_1px_0_rgba(0,0,0,0.85),_0_2px_3px_rgba(0,0,0,0.5)]';
 
-const brandExtras = `${brandDepthColors} ${brandLabelOnGradient}`;
+const brandExtras = `${brandGlowLift} ${brandLabelOnGradient}`;
 
 const PrimaryButton = React.forwardRef<HTMLButtonElement, PrimaryButtonProps>(
   ({ color, className, children, depth = true, ...props }, ref) => {
@@ -35,8 +35,8 @@ const PrimaryButton = React.forwardRef<HTMLButtonElement, PrimaryButtonProps>(
       <Button
         ref={ref}
         className={cn(
-          depth && button3DBase,
-          depth && button3DDisabled,
+          depth && buttonLift,
+          depth && buttonDisabled,
           !depth && 'shadow-lg shadow-black/30',
           isBrand ? [brandGradient, brandExtras] : [colorClasses[color], primaryTextStroke],
           className

--- a/frontend/app/components/ui/buttons/README.md
+++ b/frontend/app/components/ui/buttons/README.md
@@ -9,7 +9,7 @@ library grows, group buttons by **scope of use**, not by visual style.
 buttons/
 ├── README.md             ← this guide
 ├── index.ts              ← barrel re-export of EVERYTHING
-├── styles.ts             ← shared style constants (brandGradient, button3DBase, …)
+├── styles.ts             ← shared style constants (brandGradient, buttonLift, …)
 │
 ├── PrimaryButton.tsx     ← generic, shape-agnostic buttons live at the root
 ├── SecondaryButton.tsx
@@ -71,7 +71,7 @@ That's it. Existing imports keep working because everything funnels through the 
 
 ## Anti-patterns
 
-- ❌ Buttons that re-implement `brandGradient` / `button3DBase` instead of composing `PrimaryButton`/`SecondaryButton`/etc.
+- ❌ Buttons that re-implement `brandGradient` / `buttonLift` instead of composing `PrimaryButton`/`SecondaryButton`/etc.
 - ❌ Buttons with hand-rolled hover transitions when `transform-gpu transition-transform duration-150 hover:scale-[1.02]` is the brand-standard hover.
 - ❌ Domain-specific buttons in the root folder.
 - ❌ Buttons that import from a feature folder back into `ui/buttons/` (introduces circular dependency).

--- a/frontend/app/components/ui/buttons/SecondaryButton.tsx
+++ b/frontend/app/components/ui/buttons/SecondaryButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
 import { HotkeyBadge } from './HotkeyBadge';
-import { brandSecondary, brandSecondary3D, button3DBase, button3DDisabled } from './styles';
+import { brandSecondary, brandSecondaryLift, buttonLift, buttonDisabled } from './styles';
 
 export type SecondaryColor = 'green' | 'blue' | 'purple' | 'orange' | 'red' | 'sky' | 'cyan' | 'lime' | 'emerald';
 
@@ -10,22 +10,22 @@ export interface SecondaryButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant'> {
   /** Optional background color for contextual actions */
   color?: SecondaryColor;
-  /** Whether to apply 3D depth effects (default: false for brand, true for colored) */
+  /** Whether to apply the soft-shadow lift (default: false for brand, true for colored) */
   depth?: boolean;
   /** Optional keyboard shortcut label rendered as a badge in the top-left corner. */
   hotkey?: string;
 }
 
 const colorStyles: Record<SecondaryColor, string> = {
-  green: `${button3DBase} ${button3DDisabled} bg-green-800 hover:bg-green-700 text-white border-b-green-950 shadow-green-900/50`,
-  blue: `${button3DBase} ${button3DDisabled} bg-blue-800 hover:bg-blue-700 text-white border-b-blue-950 shadow-blue-900/50`,
-  purple: `${button3DBase} ${button3DDisabled} bg-purple-800 hover:bg-purple-700 text-white border-b-purple-950 shadow-purple-900/50`,
-  orange: `${button3DBase} ${button3DDisabled} bg-orange-800 hover:bg-orange-700 text-white border-b-orange-950 shadow-orange-900/50`,
-  red: `${button3DBase} ${button3DDisabled} bg-red-800 hover:bg-red-700 text-white border-b-red-950 shadow-red-900/50`,
-  sky: `${button3DBase} ${button3DDisabled} bg-sky-800 hover:bg-sky-700 text-white border-b-sky-950 shadow-sky-900/50`,
-  cyan: `${button3DBase} ${button3DDisabled} bg-cyan-700 hover:bg-cyan-600 text-white border-b-cyan-900 shadow-cyan-900/50`,
-  lime: `${button3DBase} ${button3DDisabled} bg-lime-700 hover:bg-lime-600 text-white border-b-lime-900 shadow-lime-900/50`,
-  emerald: `${button3DBase} ${button3DDisabled} bg-emerald-800 hover:bg-emerald-700 text-white border-b-emerald-950 shadow-emerald-900/50`,
+  green: `${buttonLift} ${buttonDisabled} bg-green-800 hover:bg-green-700 text-white shadow-green-900/50`,
+  blue: `${buttonLift} ${buttonDisabled} bg-blue-800 hover:bg-blue-700 text-white shadow-blue-900/50`,
+  purple: `${buttonLift} ${buttonDisabled} bg-purple-800 hover:bg-purple-700 text-white shadow-purple-900/50`,
+  orange: `${buttonLift} ${buttonDisabled} bg-orange-800 hover:bg-orange-700 text-white shadow-orange-900/50`,
+  red: `${buttonLift} ${buttonDisabled} bg-red-800 hover:bg-red-700 text-white shadow-red-900/50`,
+  sky: `${buttonLift} ${buttonDisabled} bg-sky-800 hover:bg-sky-700 text-white shadow-sky-900/50`,
+  cyan: `${buttonLift} ${buttonDisabled} bg-cyan-700 hover:bg-cyan-600 text-white shadow-cyan-900/50`,
+  lime: `${buttonLift} ${buttonDisabled} bg-lime-700 hover:bg-lime-600 text-white shadow-lime-900/50`,
+  emerald: `${buttonLift} ${buttonDisabled} bg-emerald-800 hover:bg-emerald-700 text-white shadow-emerald-900/50`,
 };
 
 /**
@@ -38,7 +38,7 @@ const colorStyles: Record<SecondaryColor, string> = {
  * // Brand secondary (default) - translucent violet tint
  * <SecondaryButton onClick={handleAction}>Stats</SecondaryButton>
  *
- * // With 3D depth
+ * // With soft-shadow lift
  * <SecondaryButton depth>Secondary with Depth</SecondaryButton>
  *
  * // Colored variant for contextual actions
@@ -53,7 +53,7 @@ const SecondaryButton = React.forwardRef<
   const styles = color
     ? colorStyles[color]
     : useDepth
-      ? brandSecondary3D
+      ? brandSecondaryLift
       : brandSecondary;
 
   // When hotkey is unset we must pass `children` as the single child so this

--- a/frontend/app/components/ui/buttons/SubmitButton.tsx
+++ b/frontend/app/components/ui/buttons/SubmitButton.tsx
@@ -2,7 +2,7 @@ import { Loader2 } from 'lucide-react';
 import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
-import { button3DVariants } from './styles';
+import { brandButtonVariants } from './styles';
 
 export interface SubmitButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'type'> {
@@ -10,12 +10,12 @@ export interface SubmitButtonProps
   loading?: boolean;
   /** Text to display when loading (defaults to "Submitting...") */
   loadingText?: string;
-  /** Whether to apply 3D depth effects (default: true) */
+  /** Whether to apply the soft-shadow lift (default: true) */
   depth?: boolean;
 }
 
 /**
- * A submit button with brand gradient styling and 3D depth effects for form submissions.
+ * A submit button with brand gradient styling and a soft-shadow lift for form submissions.
  * Automatically sets type="submit" and handles loading states.
  *
  * @example
@@ -47,7 +47,7 @@ const SubmitButton = React.forwardRef<HTMLButtonElement, SubmitButtonProps>(
           // min-h-11 keeps submit/approve actions the same 44px height as
           // ConfirmButton/CancelButton so dialog footers line up.
           'min-h-11',
-          depth ? button3DVariants.success : 'bg-green-600 text-white hover:bg-green-500',
+          depth ? brandButtonVariants.success : 'bg-green-600 text-white hover:bg-green-500',
           className
         )}
         {...props}

--- a/frontend/app/components/ui/buttons/SubmitButton.tsx
+++ b/frontend/app/components/ui/buttons/SubmitButton.tsx
@@ -44,6 +44,9 @@ const SubmitButton = React.forwardRef<HTMLButtonElement, SubmitButtonProps>(
         type="submit"
         disabled={disabled || loading}
         className={cn(
+          // min-h-11 keeps submit/approve actions the same 44px height as
+          // ConfirmButton/CancelButton so dialog footers line up.
+          'min-h-11',
           depth ? button3DVariants.success : 'bg-green-600 text-white hover:bg-green-500',
           className
         )}

--- a/frontend/app/components/ui/buttons/WarningButton.tsx
+++ b/frontend/app/components/ui/buttons/WarningButton.tsx
@@ -2,18 +2,18 @@ import { Loader2 } from 'lucide-react';
 import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
-import { button3DVariants } from './styles';
+import { brandButtonVariants } from './styles';
 
 export interface WarningButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant'> {
   /** Whether the button is in a loading state */
   loading?: boolean;
-  /** Whether to apply 3D depth effects (default: true) */
+  /** Whether to apply the soft-shadow lift (default: true) */
   depth?: boolean;
 }
 
 /**
- * A warning button with orange theme styling and 3D depth effects.
+ * A warning button with orange theme styling and a soft-shadow lift.
  * Used for caution-level actions that aren't destructive.
  *
  * @example
@@ -31,7 +31,7 @@ const WarningButton = React.forwardRef<HTMLButtonElement, WarningButtonProps>(
         disabled={disabled || loading}
         className={cn(
           'min-h-11',
-          depth ? button3DVariants.warning : 'bg-orange-500 text-white hover:bg-orange-400',
+          depth ? brandButtonVariants.warning : 'bg-orange-500 text-white hover:bg-orange-400',
           className
         )}
         {...props}

--- a/frontend/app/components/ui/buttons/WarningButton.tsx
+++ b/frontend/app/components/ui/buttons/WarningButton.tsx
@@ -30,6 +30,7 @@ const WarningButton = React.forwardRef<HTMLButtonElement, WarningButtonProps>(
         ref={ref}
         disabled={disabled || loading}
         className={cn(
+          'min-h-11',
           depth ? button3DVariants.warning : 'bg-orange-500 text-white hover:bg-orange-400',
           className
         )}

--- a/frontend/app/components/ui/buttons/icons/ChevronNavButton.tsx
+++ b/frontend/app/components/ui/buttons/icons/ChevronNavButton.tsx
@@ -2,7 +2,7 @@ import { ChevronsLeft, ChevronsRight } from 'lucide-react';
 import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
-import { brandDepthColors, brandGradient, button3DBase } from '../styles';
+import { brandGlowLift, brandGradient, buttonLift } from '../styles';
 
 export type ChevronDirection = 'left' | 'right';
 
@@ -44,8 +44,8 @@ const ChevronNavButton = React.forwardRef<
       className={cn(
         'rounded-full',
         brandGradient,
-        button3DBase,
-        brandDepthColors,
+        buttonLift,
+        brandGlowLift,
         '[&_svg]:text-white [&_svg]:drop-shadow-[1px_1px_1px_rgba(0,0,0,0.5)]',
         className
       )}

--- a/frontend/app/components/ui/buttons/icons/EditIconButton.tsx
+++ b/frontend/app/components/ui/buttons/icons/EditIconButton.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { FastTooltip } from '~/components/ui/tooltip';
 import { cn } from '~/lib/utils';
-import { brandToxic, brandToxicDepthColors, button3DBase } from '../styles';
+import { brandToxic, brandToxicGlowLift, buttonLift } from '../styles';
 
 export interface EditIconButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant' | 'size'> {
@@ -32,8 +32,8 @@ const EditIconButton = React.forwardRef<HTMLButtonElement, EditIconButtonProps>(
         className={cn(
           'rounded-full',
           brandToxic,
-          button3DBase,
-          brandToxicDepthColors,
+          buttonLift,
+          brandToxicGlowLift,
           '[&_svg]:text-white [&_svg]:drop-shadow-[1px_1px_1px_rgba(0,0,0,0.5)]',
           className
         )}

--- a/frontend/app/components/ui/buttons/icons/PlusIconButton.tsx
+++ b/frontend/app/components/ui/buttons/icons/PlusIconButton.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { LazyTooltip } from '~/components/ui/tooltip';
 import { cn } from '~/lib/utils';
-import { brandDepthColors, brandGradient, button3DBase } from '../styles';
+import { brandGlowLift, brandGradient, buttonLift } from '../styles';
 
 export interface PlusIconButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant' | 'size'> {
@@ -29,8 +29,8 @@ const PlusIconButton = React.forwardRef<HTMLButtonElement, PlusIconButtonProps>(
         className={cn(
           'rounded-full',
           brandGradient,
-          button3DBase,
-          brandDepthColors,
+          buttonLift,
+          brandGlowLift,
           '[&_svg]:text-white [&_svg]:drop-shadow-[1px_1px_1px_rgba(0,0,0,0.5)]',
           className
         )}

--- a/frontend/app/components/ui/buttons/icons/SendIconButton.tsx
+++ b/frontend/app/components/ui/buttons/icons/SendIconButton.tsx
@@ -24,8 +24,7 @@ const SendIconButton = React.forwardRef<HTMLButtonElement, SendIconButtonProps>(
         size="icon"
         className={cn(
           'rounded-full',
-          'shadow-lg shadow-black/30 border-b-4 border-b-secondary/50',
-          'active:border-b-0 active:translate-y-1 transition-all duration-75',
+          'shadow-lg shadow-black/30 transition-all duration-75',
           className
         )}
         {...props}

--- a/frontend/app/components/ui/buttons/icons/TrashIconButton.tsx
+++ b/frontend/app/components/ui/buttons/icons/TrashIconButton.tsx
@@ -42,8 +42,7 @@ const TrashIconButton = React.forwardRef<
       size="icon"
       className={cn(
         'rounded-full',
-        'shadow-lg shadow-red-900/50 border-b-4 border-b-red-800',
-        'active:border-b-0 active:translate-y-1 transition-all duration-75',
+        'shadow-lg shadow-red-900/50 transition-all duration-75',
         sizeConfig.button,
         className
       )}

--- a/frontend/app/components/ui/buttons/icons/ViewIconButton.tsx
+++ b/frontend/app/components/ui/buttons/icons/ViewIconButton.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { FastTooltip } from '~/components/ui/tooltip';
 import { cn } from '~/lib/utils';
-import { brandDepthColors, brandGradient, button3DBase } from '../styles';
+import { brandGlowLift, brandGradient, buttonLift } from '../styles';
 
 export interface ViewIconButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant' | 'size'> {
@@ -29,8 +29,8 @@ const ViewIconButton = React.forwardRef<HTMLButtonElement, ViewIconButtonProps>(
         className={cn(
           'rounded-full',
           brandGradient,
-          button3DBase,
-          brandDepthColors,
+          buttonLift,
+          brandGlowLift,
           '[&_svg]:text-white [&_svg]:drop-shadow-[1px_1px_1px_rgba(0,0,0,0.5)]',
           className
         )}

--- a/frontend/app/components/ui/buttons/index.ts
+++ b/frontend/app/components/ui/buttons/index.ts
@@ -1,6 +1,6 @@
 // Shared styles
-export { brandBg, brandDepthColors, brandDialogPanel, brandErrorBg, brandErrorCard, brandErrorPrimary, brandGlow, brandGradient, brandHighlight, brandHighlightText, brandLabelOnGradient, brandReadableDestructive, brandReadableSuccess, brandReadableWarning, brandSecondary, brandSecondary3D, brandSecondaryOpaque, brandSecondaryOpaque3D, brandSuccessBg, button3DBase, button3DDisabled, button3DVariants } from './styles';
-export type { Button3DVariant } from './styles';
+export { brandBg, brandGlowLift, brandDialogPanel, brandErrorBg, brandErrorCard, brandErrorPrimary, brandGlow, brandGradient, brandHighlight, brandHighlightText, brandLabelOnGradient, brandReadableDestructive, brandReadableSuccess, brandReadableWarning, brandSecondary, brandSecondaryLift, brandSecondaryOpaque, brandSecondaryOpaqueLift, brandSuccessBg, buttonLift, buttonDisabled, brandButtonVariants } from './styles';
+export type { BrandButtonVariant } from './styles';
 
 // Shared affordances
 export { HotkeyBadge } from './HotkeyBadge';

--- a/frontend/app/components/ui/buttons/styles.ts
+++ b/frontend/app/components/ui/buttons/styles.ts
@@ -90,13 +90,18 @@ export const brandErrorCard = 'bg-red-900/60 border border-red-500/15';
 // Brand error primary - lighter red for interactive error elements (buttons, close icons)
 export const brandErrorPrimary = 'bg-gradient-to-r from-red-700/80 to-violet-900/80 hover:from-red-600/80 hover:to-violet-800/80 text-white';
 
-// Base 3D button effect classes (active state removed for disabled buttons via CSS)
+// Base button lift — flat by design. The old chunky bevel
+// (`border-b-4 active:border-b-0 active:translate-y-1`) was removed so action
+// buttons read clean and consistent (no mix of 3D / non-3D across a footer).
+// A soft drop shadow keeps the surface separated from the dialog; press
+// feedback comes from <Button>'s `active:scale-[0.95]` (button.tsx). Per-variant
+// `border-b-<color>` accents below are now inert (width 0) and harmless.
 export const button3DBase =
-  'shadow-lg shadow-black/30 border-b-4 active:border-b-0 active:translate-y-1 transition-all duration-75';
+  'shadow-lg shadow-black/30 transition-all duration-75';
 
-// Disabled state styling - removes 3D effects and uses muted colors
+// Disabled state styling - removes lift and uses muted colors
 export const button3DDisabled =
-  'disabled:shadow-none disabled:border-b-0 disabled:translate-y-0 disabled:bg-gray-400 disabled:text-gray-600 disabled:cursor-not-allowed disabled:opacity-70';
+  'disabled:shadow-none disabled:bg-gray-400 disabled:text-gray-600 disabled:cursor-not-allowed disabled:opacity-70';
 
 // Icon styling to ensure icons inherit text color
 const iconWhite = '[&_svg]:text-white [&_svg]:drop-shadow-[1px_1px_1px_rgba(0,0,0,0.5)]';

--- a/frontend/app/components/ui/buttons/styles.ts
+++ b/frontend/app/components/ui/buttons/styles.ts
@@ -1,5 +1,5 @@
 /**
- * Shared button style constants for 3D effects and variants
+ * Shared button style constants — flat surfaces with a soft-shadow lift.
  */
 
 // Brand gradient - single source of truth for primary action buttons
@@ -18,13 +18,11 @@ export const brandSecondary = 'bg-gradient-to-r from-violet-500/30 to-blue-500/2
 // (e.g. bg-background on dialogs). Applied by default to Dialog and AlertDialog content.
 export const brandBg = '[background-image:var(--brand-bg)]';
 
-// Brand 3D depth colors — deep indigo bottom edge bridges the violet→blue
-// gradient (instead of fighting it the way `violet-700` did), and the drop
-// shadow swaps generic black for a brand-violet glow with a subtle 1px
-// inner-top highlight that reads as "lit from above". Together this gives
-// the brand primary a neon-cyber lift without the chunky-bevel feel.
-export const brandDepthColors =
-  'border-b-indigo-950 shadow-[0_8px_20px_-8px_var(--glow-violet),inset_0_1px_0_rgba(255,255,255,0.18)]';
+// Brand glow lift for the violet→blue gradient — a brand-violet drop shadow
+// plus a subtle 1px inner-top highlight that reads as "lit from above",
+// giving the brand primary a neon-cyber lift without any bevel.
+export const brandGlowLift =
+  'shadow-[0_8px_20px_-8px_var(--glow-violet),inset_0_1px_0_rgba(255,255,255,0.18)]';
 
 // Brand glow shadow - visible on dark backgrounds, matches brand gradient
 // Defined as --shadow-brand-glow in @theme (app.css) for use with variants
@@ -80,7 +78,7 @@ export const brandHighlightText = 'bg-gradient-to-r from-emerald-400 to-violet-4
 // against the slate base without competing with the primary CTA gradient.
 export const brandToxic =
   'bg-gradient-to-br from-violet-700 via-emerald-800 to-emerald-700 hover:from-violet-600 hover:via-emerald-700 hover:to-emerald-600 text-white';
-export const brandToxicDepthColors = 'border-b-emerald-900 shadow-emerald-950/60';
+export const brandToxicGlowLift = 'shadow-emerald-950/60';
 
 // Brand error surfaces - muted deep wine/red tones for error containers.
 // Uses raw Tailwind colors (not semantic --error/--primary) because error surfaces
@@ -91,16 +89,16 @@ export const brandErrorCard = 'bg-red-900/60 border border-red-500/15';
 export const brandErrorPrimary = 'bg-gradient-to-r from-red-700/80 to-violet-900/80 hover:from-red-600/80 hover:to-violet-800/80 text-white';
 
 // Base button lift — flat by design. The old chunky bevel
-// (`border-b-4 active:border-b-0 active:translate-y-1`) was removed so action
-// buttons read clean and consistent (no mix of 3D / non-3D across a footer).
-// A soft drop shadow keeps the surface separated from the dialog; press
-// feedback comes from <Button>'s `active:scale-[0.95]` (button.tsx). Per-variant
-// `border-b-<color>` accents below are now inert (width 0) and harmless.
-export const button3DBase =
+// (`border-b-4 active:border-b-0 active:translate-y-1` plus per-variant
+// `border-b-<color>` accents) was removed so action buttons read clean and
+// consistent — no mix of bevelled and flat across a footer. A soft drop
+// shadow keeps the surface separated from the dialog; press feedback comes
+// from <Button>'s `active:scale-[0.95]` (button.tsx).
+export const buttonLift =
   'shadow-lg shadow-black/30 transition-all duration-75';
 
 // Disabled state styling - removes lift and uses muted colors
-export const button3DDisabled =
+export const buttonDisabled =
   'disabled:shadow-none disabled:bg-gray-400 disabled:text-gray-600 disabled:cursor-not-allowed disabled:opacity-70';
 
 // Icon styling to ensure icons inherit text color
@@ -110,26 +108,26 @@ const iconMuted = 'disabled:[&_svg]:text-gray-600 disabled:[&_svg]:drop-shadow-n
 // Brand secondary opaque - for use on colored backgrounds (dialogs) where translucency bleeds
 export const brandSecondaryOpaque = 'bg-violet-950 border border-violet-400/30 text-violet-100 hover:bg-violet-900';
 
-// Brand secondary with 3D depth
-export const brandSecondary3D = `${button3DBase} ${button3DDisabled} ${brandSecondary} border-b-violet-700/50`;
+// Brand secondary with soft-shadow lift
+export const brandSecondaryLift = `${buttonLift} ${buttonDisabled} ${brandSecondary}`;
 
-// Brand secondary opaque with 3D depth (for colored dialog backgrounds)
-export const brandSecondaryOpaque3D = `${button3DBase} ${button3DDisabled} ${brandSecondaryOpaque} border-b-violet-700/50`;
+// Brand secondary opaque with soft-shadow lift (for colored dialog backgrounds)
+export const brandSecondaryOpaqueLift = `${buttonLift} ${buttonDisabled} ${brandSecondaryOpaque}`;
 
 // Neutral opaque - gray/slate for cancel buttons on colored dialog backgrounds
 export const brandNeutralOpaque = 'bg-slate-700 border border-slate-500/30 text-slate-100 hover:bg-slate-600';
-export const brandNeutralOpaque3D = `${button3DBase} ${button3DDisabled} ${brandNeutralOpaque} border-b-slate-800/50`;
+export const brandNeutralOpaqueLift = `${buttonLift} ${buttonDisabled} ${brandNeutralOpaque}`;
 
-// Variant-specific 3D styles with disabled state
-export const button3DVariants = {
-  destructive: `${button3DBase} ${button3DDisabled} ${iconWhite} ${iconMuted} bg-red-600 text-white hover:bg-red-500 border-b-red-800 shadow-red-900/50`,
-  warning: `${button3DBase} ${button3DDisabled} ${iconWhite} ${iconMuted} bg-orange-500 text-white hover:bg-orange-400 border-b-orange-700 shadow-orange-900/50`,
-  success: `${button3DBase} ${button3DDisabled} ${iconWhite} ${iconMuted} ${brandGradient} ${brandDepthColors}`,
-  primary: `${button3DBase} ${button3DDisabled} bg-primary text-primary-foreground hover:bg-primary/90 border-b-primary/50`,
-  secondary: `${brandSecondary3D}`,
-  outline: `${button3DBase} ${button3DDisabled} border-b-gray-600`,
-  edit: `${button3DBase} ${button3DDisabled} ${iconWhite} ${iconMuted} ${brandToxic} ${brandToxicDepthColors}`,
-  nav: `${button3DBase} ${button3DDisabled} ${iconWhite} ${iconMuted} bg-sky-700 text-white hover:bg-sky-600 border-b-sky-900 shadow-sky-900/50`,
+// Variant-specific styles (flat fill + lift) with disabled state
+export const brandButtonVariants = {
+  destructive: `${buttonLift} ${buttonDisabled} ${iconWhite} ${iconMuted} bg-red-600 text-white hover:bg-red-500 shadow-red-900/50`,
+  warning: `${buttonLift} ${buttonDisabled} ${iconWhite} ${iconMuted} bg-orange-500 text-white hover:bg-orange-400 shadow-orange-900/50`,
+  success: `${buttonLift} ${buttonDisabled} ${iconWhite} ${iconMuted} ${brandGradient} ${brandGlowLift}`,
+  primary: `${buttonLift} ${buttonDisabled} bg-primary text-primary-foreground hover:bg-primary/90`,
+  secondary: `${brandSecondaryLift}`,
+  outline: `${buttonLift} ${buttonDisabled}`,
+  edit: `${buttonLift} ${buttonDisabled} ${iconWhite} ${iconMuted} ${brandToxic} ${brandToxicGlowLift}`,
+  nav: `${buttonLift} ${buttonDisabled} ${iconWhite} ${iconMuted} bg-sky-700 text-white hover:bg-sky-600 shadow-sky-900/50`,
 } as const;
 
-export type Button3DVariant = keyof typeof button3DVariants;
+export type BrandButtonVariant = keyof typeof brandButtonVariants;

--- a/frontend/app/components/ui/buttons/user/DotabuffIconButton.tsx
+++ b/frontend/app/components/ui/buttons/user/DotabuffIconButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
-import { brandSecondary, button3DBase } from '../styles';
+import { brandSecondary, buttonLift } from '../styles';
 
 export interface DotabuffIconButtonProps
   extends Omit<React.ComponentProps<typeof Button>, 'variant' | 'size' | 'asChild'> {
@@ -39,7 +39,7 @@ const DotabuffIconButton = React.forwardRef<HTMLButtonElement, DotabuffIconButto
         className={cn(
           'rounded-full',
           brandSecondary,
-          button3DBase,
+          buttonLift,
           'border-b-violet-700/50 shadow-black/30',
           className,
         )}

--- a/frontend/app/components/ui/dialog.tsx
+++ b/frontend/app/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
   closeButtonTestId?: string
 }) {
   const closeButtonStyles = closeButtonVariant === 'destructive'
-    ? "bg-gradient-to-r from-red-700 to-violet-900 hover:from-red-600 hover:to-violet-800 text-white outline-none rounded-md p-1.5 opacity-100 shadow-lg active:translate-y-0.5 transition-none"
+    ? "bg-gradient-to-r from-red-700 to-violet-900 hover:from-red-600 hover:to-violet-800 text-white outline-none rounded-md p-1.5 opacity-100 shadow-lg transition-none"
     : "ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none";
 
   return (

--- a/frontend/app/components/ui/dialogs/ConfirmDialog.tsx
+++ b/frontend/app/components/ui/dialogs/ConfirmDialog.tsx
@@ -83,7 +83,7 @@ const confirmButtonVariantMap: Record<string, ConfirmButtonVariant> = {
 
 /**
  * Standardized confirmation dialog for destructive or important actions.
- * Uses reusable ConfirmButton and CancelButton components with 3D depth effects.
+ * Uses reusable ConfirmButton and CancelButton components with a soft-shadow lift.
  *
  * @example
  * <ConfirmDialog

--- a/frontend/app/components/ui/mobile-actions-dropdown.tsx
+++ b/frontend/app/components/ui/mobile-actions-dropdown.tsx
@@ -8,8 +8,8 @@ import {
 } from '~/components/ui/dropdown-menu';
 import {
   brandBg,
-  brandDepthColors,
-  button3DBase,
+  brandGlowLift,
+  buttonLift,
 } from '~/components/ui/buttons';
 import { cn } from '~/lib/utils';
 
@@ -55,9 +55,9 @@ export function MobileActionsDropdown({
         <Button
           data-testid={testId}
           className={cn(
-            button3DBase,
+            buttonLift,
             brandBg,
-            `border border-primary/25 ${brandDepthColors}`,
+            `border border-primary/25 ${brandGlowLift}`,
             'text-foreground',
             className,
           )}

--- a/frontend/app/components/ui/mobile-nav-dropdown.tsx
+++ b/frontend/app/components/ui/mobile-nav-dropdown.tsx
@@ -54,7 +54,7 @@ export function MobileNavDropdown({
       className={cn(
         'rounded-lg',
         isPrimary
-          ? [brandGradient, `shadow-lg border-b-4 ${brandDepthColors}`]
+          ? [brandGradient, `shadow-lg ${brandDepthColors}`]
           : brandSecondary,
         className,
       )}

--- a/frontend/app/components/ui/mobile-nav-dropdown.tsx
+++ b/frontend/app/components/ui/mobile-nav-dropdown.tsx
@@ -5,7 +5,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '~/components/ui/select';
-import { brandDepthColors, brandGradient, brandSecondary } from '~/components/ui/buttons';
+import { brandGlowLift, brandGradient, brandSecondary } from '~/components/ui/buttons';
 import { cn } from '~/lib/utils';
 
 export interface MobileNavOption {
@@ -32,7 +32,7 @@ interface MobileNavDropdownProps {
 
 /**
  * Branded mobile dropdown that replaces tab bars on narrow screens.
- * Primary variant: bold gradient with 3D depth for navbar.
+ * Primary variant: bold gradient lift for navbar.
  * Secondary variant: subtle translucent gradient for in-page tabs.
  */
 export function MobileNavDropdown({
@@ -54,7 +54,7 @@ export function MobileNavDropdown({
       className={cn(
         'rounded-lg',
         isPrimary
-          ? [brandGradient, `shadow-lg ${brandDepthColors}`]
+          ? [brandGradient, `shadow-lg ${brandGlowLift}`]
           : brandSecondary,
         className,
       )}


### PR DESCRIPTION
Closes #265.

Two commits: the visual fix, then a naming/dead-code consolidation (folded in per discussion).

## 1. `fix(buttons)` — flatten bevel + align footer heights
Dialog-footer buttons looked mismatched (per the issue screenshots): uneven heights, two clashing reds, and a chunky 3D bevel on some buttons but not others.

- **Flatten** `buttonLift` (formerly `button3DBase`) — drop the `border-b-4` + `active:translate-y` bevel, keep the soft-shadow lift. Press feedback comes from `<Button>`'s `active:scale-[0.95]`.
- **Flatten inline strays** — `TrashIconButton`, `SendIconButton`, `mobile-nav-dropdown`, destructive `dialog.tsx` close.
- **Standardize height** — `min-h-11` on `SubmitButton` / `DestructiveButton` / `WarningButton`; all footer action buttons are now a uniform 44px.
- **MMR modal** — "Close" → neutral `CancelButton`. Footer reads **neutral · red · blue**.

## 2. `refactor(buttons)` — drop vestigial 3D naming + dead classes
Once flat, the "3D"/"depth" vocabulary and per-variant `border-b-<color>` accents were misleading dead weight. Pure cleanup, no visual/behavioral change; `depth` props kept for compatibility.

- Renames: `button3DBase→buttonLift`, `button3DDisabled→buttonDisabled`, `button3DVariants→brandButtonVariants`, `brandDepthColors→brandGlowLift`, `brandToxicDepthColors→brandToxicGlowLift`, `*3D→*Lift`.
- Stripped inert `border-b-<color>` accents across every variant + the teamdraft filter pills (kept real shadows/glow).
- Updated `depth`-prop JSDoc + /brand docs (constants table, **Button Lift** section, **Footer Button Height** standard, selection guide, review-checklist + grep recipe).

## Verification
- `react-router typegen && tsc`: **zero errors in any file this PR touches**; total error count unchanged at 57 vs. baseline (all pre-existing — see note).
- Confirmed zero remaining `border-b-4` / `active:translate-y` and zero old `*3D*` identifiers in the frontend.

## Note (pre-existing, unrelated)
The repo has ~57 pre-existing `tsc` errors on `main` (there are dedicated `fix/app-code-tsc-errors` branches). This PR neither adds nor fixes any — e.g. `app/routes/league.tsx:84`, `app/routes/user.tsx:33`.