### PR TITLE
fix(events): delete Discord scheduled events when a series is deleted

### DIFF
--- a/backend/events/tasks.py
+++ b/backend/events/tasks.py
@@ -1001,6 +1001,45 @@ def _create_discord_scheduled_event_impl(event_id):
 
 
 @shared_task
+def delete_discord_scheduled_event(guild_id: str, scheduled_event_id: str) -> str:
+    """Delete a live Discord guild scheduled event.
+
+    Idempotent: a 404 (already gone) counts as success. Nothing else in the app
+    removes scheduled events, so this must run whenever an Event or its series is
+    deleted — otherwise the event is orphaned on the guild and sync_discord_events
+    keeps it alive as a "ghost".
+    """
+    if not guild_id or not scheduled_event_id:
+        return "Skipped: missing guild_id or scheduled_event_id"
+    url = f"{DISCORD_API_BASE}/guilds/{guild_id}/scheduled-events/{scheduled_event_id}"
+    try:
+        response = req.delete(url, headers=_get_headers())
+        if response.status_code not in (204, 404):
+            logger.error(
+                "discord_scheduled_event_delete_failed",
+                system="events",
+                subsystem="tasks",
+                guild_id=guild_id,
+                scheduled_event_id=scheduled_event_id,
+                status_code=response.status_code,
+            )
+        return (
+            f"Deleted Discord scheduled event {scheduled_event_id} "
+            f"(HTTP {response.status_code})"
+        )
+    except Exception as e:
+        logger.exception(
+            "discord_scheduled_event_delete_error",
+            system="events",
+            subsystem="tasks",
+            guild_id=guild_id,
+            scheduled_event_id=scheduled_event_id,
+            error=str(e),
+        )
+        return f"Failed: {e}"
+
+
+@shared_task
 def sync_discord_event_signups(event_id, interaction_id=None):
     """Sync signup count to Discord scheduled event description."""
     return _run_with_bookends(

--- a/backend/events/tests/test_series_delete_cleanup.py
+++ b/backend/events/tests/test_series_delete_cleanup.py
@@ -1,0 +1,89 @@
+"""Deleting an event series (EventRepeater) must clean up its future events and
+their live Discord scheduled events, so the every-60s sync_discord_events task
+can't resurrect them as "ghost" events.
+
+Regression for: deleted series kept generating ghost Discord events because
+EventRepeaterViewSet was a plain ModelViewSet (hard delete, Event.event_repeater
+SET_NULL) with no teardown, and nothing ever DELETEs the live Discord event.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.utils import timezone as tz
+from rest_framework.test import APIClient
+
+from discordbot.models import DiscordEvent
+from events.constants import EventState, RepeatFrequency
+from events.models import Event, EventRepeater
+from events.tests.base import EventTestCase
+
+
+class SeriesDeleteCleanupTest(EventTestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.org.discord_server_id = "734185035623825559"
+        self.org.save(update_fields=["discord_server_id"])
+
+        self.repeater = EventRepeater.objects.create(
+            organization=self.org,
+            name="Sunday Turbo Tournament",
+            frequency=RepeatFrequency.WEEKLY,
+            day_of_week=0,
+            time_of_day="18:00",
+            starts_at=tz.now().date(),
+            created_by=self.admin,
+        )
+
+        # A future, still-active occurrence with a live Discord scheduled event.
+        self.future_event = Event.objects.create(
+            organization=self.org,
+            event_repeater=self.repeater,
+            name="Sunday Turbo Tournament",
+            scheduled_at=tz.now() + timedelta(days=5),
+            state=EventState.UPCOMING,
+            discord_create_event=True,
+        )
+        self.discord_event = DiscordEvent.objects.create(
+            event=self.future_event,
+            guild_id="734185035623825559",
+            scheduled_event_id="1529289108529352788",
+        )
+
+        # A past occurrence — must be preserved (orphaned), not deleted.
+        self.past_event = Event.objects.create(
+            organization=self.org,
+            event_repeater=self.repeater,
+            name="Sunday Turbo Tournament",
+            scheduled_at=tz.now() - timedelta(days=5),
+            state=EventState.COMPLETED,
+        )
+
+    @patch("events.tasks.delete_discord_scheduled_event")
+    def test_delete_series_removes_future_events_and_discord(self, mock_delete_task):
+        self.client.force_authenticate(self.admin)
+        resp = self.client.delete(f"/api/events/repeaters/{self.repeater.pk}/")
+        self.assertEqual(resp.status_code, 204, resp.content)
+
+        # Series gone.
+        self.assertFalse(EventRepeater.objects.filter(pk=self.repeater.pk).exists())
+        # Future occurrence + its Discord row gone.
+        self.assertFalse(Event.objects.filter(pk=self.future_event.pk).exists())
+        self.assertFalse(DiscordEvent.objects.filter(pk=self.discord_event.pk).exists())
+        # Live Discord scheduled event deletion was dispatched.
+        mock_delete_task.delay.assert_called_once_with(
+            "734185035623825559", "1529289108529352788"
+        )
+        # Past occurrence preserved, now orphaned.
+        self.past_event.refresh_from_db()
+        self.assertIsNone(self.past_event.event_repeater_id)
+
+    @patch("events.tasks.delete_discord_scheduled_event")
+    def test_delete_single_event_deletes_live_discord_event(self, mock_delete_task):
+        self.client.force_authenticate(self.admin)
+        resp = self.client.delete(f"/api/events/{self.future_event.pk}/")
+        self.assertEqual(resp.status_code, 204, resp.content)
+        mock_delete_task.delay.assert_called_once_with(
+            "734185035623825559", "1529289108529352788"
+        )
+        self.assertFalse(DiscordEvent.objects.filter(pk=self.discord_event.pk).exists())

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -102,6 +102,46 @@ def _attach_user_can_manage(payload, user):
     return payload
 
 
+def _teardown_event(event):
+    """Delete an event and everything Discord/tournament-related it owns.
+
+    Dispatches deletion of the live Discord scheduled event (nothing else in the
+    app removes scheduled events), then removes the linked tournament, DiscordEvent
+    (cascades to messages, logs, DMs) and legacy message logs, then the event row.
+    Shared by EventViewSet (single delete) and EventRepeaterViewSet (series delete)
+    so both paths clean up identically and can't leave ghost events behind.
+    """
+    from app.cache_utils import invalidate_after_commit
+    from discordbot.models import DiscordEvent, DiscordMessageLog
+    from events.tasks import delete_discord_scheduled_event
+
+    with transaction.atomic():
+        invalidate_after_commit(event)
+        if event.tournament:
+            tournament = event.tournament
+            event.tournament = None
+            event.save(update_fields=["tournament", "updated_at"])
+            tournament.delete()
+
+        try:
+            discord_event = event.discord_event
+        except DiscordEvent.DoesNotExist:
+            discord_event = None
+        if discord_event is not None:
+            if discord_event.scheduled_event_id:
+                delete_discord_scheduled_event.delay(
+                    discord_event.guild_id, discord_event.scheduled_event_id
+                )
+            discord_event.delete()
+
+        DiscordMessageLog.objects.filter(
+            source__in=["event_announcement", "event_notice"],
+            source_id=event.pk,
+        ).delete()
+
+        event.delete()
+
+
 class EventRepeaterViewSet(viewsets.ModelViewSet):
     serializer_class = EventRepeaterSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -116,6 +156,21 @@ class EventRepeaterViewSet(viewsets.ModelViewSet):
         if self.action in ("update", "partial_update", "destroy"):
             if not has_org_staff_access(request.user, obj.organization):
                 self.permission_denied(request)
+
+    def perform_destroy(self, instance):
+        """Tear down the series' still-active occurrences (and their live Discord
+        scheduled events) before deleting the series, so sync_discord_events can't
+        resurrect them as ghosts. Terminal (completed/cancelled) occurrences are
+        left as orphans via Event.event_repeater=SET_NULL for historical record.
+        """
+        active_states = [
+            EventState.UPCOMING,
+            EventState.SIGNUPS_OPEN,
+            EventState.ROLL_CALL,
+        ]
+        for event in list(instance.events.filter(state__in=active_states)):
+            _teardown_event(event)
+        instance.delete()
 
     def get_queryset(self):
         from django.db.models import Min
@@ -628,35 +683,7 @@ class EventViewSet(viewsets.ModelViewSet):
 
     def perform_destroy(self, instance):
         """Clean up tournament and Discord messages before deleting event."""
-        from app.cache_utils import invalidate_after_commit
-
-        with transaction.atomic():
-            invalidate_after_commit(instance)
-            # Delete linked tournament
-            if instance.tournament:
-                tournament = instance.tournament
-                instance.tournament = None
-                instance.save(update_fields=["tournament", "updated_at"])
-                tournament.delete()
-
-            # Delete DiscordEvent (cascades to messages, logs, DMs)
-            from discordbot.models import DiscordEvent
-
-            try:
-                discord_event = instance.discord_event
-                discord_event.delete()
-            except DiscordEvent.DoesNotExist:
-                pass
-
-            # Clean up legacy DiscordMessageLog entries for pre-migration data
-            from discordbot.models import DiscordMessageLog
-
-            DiscordMessageLog.objects.filter(
-                source__in=["event_announcement", "event_notice"],
-                source_id=instance.pk,
-            ).delete()
-
-            instance.delete()
+        _teardown_event(instance)
 
     @action(detail=True, methods=["post"])
     def cancel(self, request, pk=None):


### PR DESCRIPTION
## Summary

Deleting an event series (`EventRepeater`) left "ghost" Discord scheduled events that kept reappearing on prod. Root cause: `EventRepeaterViewSet` was a plain `ModelViewSet` (hard delete + `Event.event_repeater=SET_NULL` orphans its events), and **nothing in the app ever deletes a live Discord scheduled event** — `sync_discord_events` only ever *creates*. So every 60s it re-POSTed a fresh scheduled event for the orphaned occurrences.

## Changes

- **`events/tasks.py`**: new `delete_discord_scheduled_event` task — idempotent `DELETE /guilds/{id}/scheduled-events/{id}` (404 counts as success). This is the missing deletion path.
- **`events/views.py`**: extracted shared `_teardown_event()` (dispatches the Discord delete, then removes tournament / DiscordEvent / message logs / event), used by both `EventViewSet.perform_destroy` and a **new `EventRepeaterViewSet.perform_destroy`** that tears down active occurrences (`upcoming` / `signups_open` / `roll_call` — exactly what sync resurrects) before deleting the series. Terminal occurrences stay as orphans for history.

## Test plan

- `events/tests/test_series_delete_cleanup.py` (new): verifies deleting a series removes its future events + DiscordEvent rows, dispatches the live Discord delete, and preserves past occurrences as orphans; plus single-event delete dispatches the Discord delete.
- Verified red→green locally; full `events.tests` suite passes in Docker with no new failures.

Prod already remediated manually (series deactivated, ghost event + row deleted, guild scheduled-events list empty).