### PR TITLE
fix(types): take the frontend typecheck from 57 errors to 0

### DIFF
--- a/frontend/app/components/api/axios.tsx
+++ b/frontend/app/components/api/axios.tsx
@@ -48,8 +48,8 @@ api.interceptors.response.use(undefined, (error) => {
     if (!isAuthCheck && typeof window !== 'undefined') {
       // Only show once per session to avoid toast spam
       const key = '_auth_toast_shown';
-      if (!(window as Record<string, unknown>)[key]) {
-        (window as Record<string, unknown>)[key] = true;
+      if (!(window as unknown as Record<string, unknown>)[key]) {
+        (window as unknown as Record<string, unknown>)[key] = true;
         // Dynamic import to avoid circular deps
         import('sonner').then(({ toast }) => {
           toast.error('Session expired — please log in again', {
@@ -61,7 +61,7 @@ api.interceptors.response.use(undefined, (error) => {
           });
         });
         // Reset after 30s so it can show again if needed
-        setTimeout(() => { (window as Record<string, unknown>)[key] = false; }, 30000);
+        setTimeout(() => { (window as unknown as Record<string, unknown>)[key] = false; }, 30000);
       }
     }
   }

--- a/frontend/app/components/api/bracketAPI.tsx
+++ b/frontend/app/components/api/bracketAPI.tsx
@@ -1,6 +1,7 @@
 import { api } from './axios';
 import { BracketResponseSchema } from '~/components/bracket/schemas';
-import type { BracketMatch, BracketResponse } from '~/components/bracket/types';
+import type { BracketMatch } from '~/components/bracket/types';
+import type { BracketResponseDTO } from '~/components/bracket/schemas';
 
 /**
  * Save bracket matches to backend
@@ -8,7 +9,7 @@ import type { BracketMatch, BracketResponse } from '~/components/bracket/types';
 export async function saveBracket(
   tournamentId: number,
   matches: BracketMatch[]
-): Promise<BracketResponse> {
+): Promise<BracketResponseDTO> {
   const response = await api.post(`/bracket/tournaments/${tournamentId}/save/`, {
     matches,
   });
@@ -18,7 +19,7 @@ export async function saveBracket(
 /**
  * Load bracket from backend
  */
-export async function loadBracket(tournamentId: number): Promise<BracketResponse> {
+export async function loadBracket(tournamentId: number): Promise<BracketResponseDTO> {
   const response = await api.get(`/bracket/tournaments/${tournamentId}/`);
   return BracketResponseSchema.parse(response.data);
 }

--- a/frontend/app/components/herodraft/HeroDraftModal.tsx
+++ b/frontend/app/components/herodraft/HeroDraftModal.tsx
@@ -483,7 +483,7 @@ export function HeroDraftModal({ draftId, open, onClose }: HeroDraftModalProps) 
                     <h2 className="text-2xl font-bold" data-testid="herodraft-flip-winner">
                       {rollWinnerTeam?.captain ? DisplayName(rollWinnerTeam.captain) : 'Unknown'} won the flip!
                     </h2>
-                    {isCaptain && rollWinnerTeam?.id === myTeam?.id ? (
+                    {isCaptain && myTeam && rollWinnerTeam?.id === myTeam.id ? (
                       // Winner captain's turn - check if they already made their choice
                       myTeam.is_first_pick !== null || myTeam.is_radiant !== null ? (
                         // Winner already made their choice, waiting for loser

--- a/frontend/app/components/player/PlayerModal.tsx
+++ b/frontend/app/components/player/PlayerModal.tsx
@@ -166,8 +166,9 @@ export const PlayerModal: React.FC<PlayerModalProps> = ({
     if (!player.pk || !currentUser?.pk) return;
 
     setIsClaiming(true);
+    const claim = claimUserProfile(player.pk);
     toast.promise(
-      claimUserProfile(player.pk),
+      claim,
       {
         loading: 'Claiming profile...',
         success: (updatedUser) => {
@@ -181,7 +182,15 @@ export const PlayerModal: React.FC<PlayerModalProps> = ({
           return err?.response?.data?.error || 'Failed to claim profile';
         },
       }
-    ).finally(() => setIsClaiming(false));
+    );
+
+    try {
+      await claim;
+    } catch {
+      // toast.promise already surfaced the failure to the user.
+    } finally {
+      setIsClaiming(false);
+    }
   };
 
   return (

--- a/frontend/app/components/team/teamTable/teamTable.tsx
+++ b/frontend/app/components/team/teamTable/teamTable.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from '~/components/ui/table';
+import { DisplayName } from '~/components/user/avatar';
 import { RolePositions } from '~/components/user/positions';
 import type { UserType } from '~/components/user/types';
 import { UserStrip } from '~/components/user/UserStrip';
@@ -126,19 +127,13 @@ export const TeamTable: React.FC<TeamTableProps> = memo(({ team, compact = false
                     className="hover:ring-2 hover:ring-primary transition-all"
                   />
                   <span className={compact ? "hidden" : "hidden 3xl:inline"}>
-                    {user.nickname || user.username}
+                    {DisplayName(user)}
                   </span>
                   <span
                     className={compact ? "inline" : "inline 3xl:hidden"}
-                    title={user.nickname || user.username}
+                    title={DisplayName(user)}
                   >
-                    {compact
-                      ? (user.nickname || user.username).length > 6
-                        ? `${(user.nickname || user.username).substring(0, 6)}…`
-                        : user.nickname || user.username
-                      : (user.nickname || user.username).length > 10
-                        ? `${(user.nickname || user.username).substring(0, 12)}...`
-                        : user.nickname || user.username}
+                    {DisplayName(user, compact ? 6 : 12)}
                   </span>
                 </div>
               </PlayerPopover>

--- a/frontend/app/components/ui/buttons/ConfirmButton.tsx
+++ b/frontend/app/components/ui/buttons/ConfirmButton.tsx
@@ -17,6 +17,8 @@ export interface ConfirmButtonProps
   depth?: boolean;
   /** Optional keyboard shortcut label rendered as a badge in the top-left corner. */
   hotkey?: string;
+  /** Overrides the variant's default loading label (e.g. "Applying..."). */
+  loadingText?: string;
 }
 
 /**
@@ -54,6 +56,7 @@ const ConfirmButton = React.forwardRef<HTMLButtonElement, ConfirmButtonProps>(
       variant = 'default',
       depth = true,
       hotkey,
+      loadingText,
       ...props
     },
     ref
@@ -65,7 +68,7 @@ const ConfirmButton = React.forwardRef<HTMLButtonElement, ConfirmButtonProps>(
       success: depth ? brandButtonVariants.success : brandGradient,
     };
 
-    const loadingText = {
+    const defaultLoadingText = {
       default: 'Confirming...',
       destructive: 'Deleting...',
       warning: 'Processing...',
@@ -77,7 +80,7 @@ const ConfirmButton = React.forwardRef<HTMLButtonElement, ConfirmButtonProps>(
     const inner = loading ? (
       <>
         <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-        {loadingText[variant]}
+        {loadingText ?? defaultLoadingText[variant]}
       </>
     ) : (
       children

--- a/frontend/app/components/ui/dialogs/InfoDialog.tsx
+++ b/frontend/app/components/ui/dialogs/InfoDialog.tsx
@@ -18,8 +18,8 @@ export interface InfoDialogProps {
   open: boolean;
   /** Callback when open state changes */
   onOpenChange: (open: boolean) => void;
-  /** Dialog title */
-  title: string;
+  /** Dialog title. Accepts a node so callers can attach test ids / markup. */
+  title: React.ReactNode;
   /** Dialog description for accessibility (visually hidden if not provided) */
   description?: string;
   /** Dialog content */
@@ -74,7 +74,7 @@ export const InfoDialog = React.forwardRef<HTMLDivElement, InfoDialogProps>(
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>
             <DialogDescription className={description ? '' : 'sr-only'}>
-              {description || `${title} dialog`}
+              {description || (typeof title === 'string' ? `${title} dialog` : 'Dialog')}
             </DialogDescription>
           </DialogHeader>
 

--- a/frontend/app/components/ui/simple-avatar.tsx
+++ b/frontend/app/components/ui/simple-avatar.tsx
@@ -33,7 +33,7 @@ export const SimpleAvatar = memo(function SimpleAvatar({
     onError?.();
   }, [onError]);
 
-  const showImage = src && !hasError;
+  const showImage = !!src && !hasError;
 
   return (
     <div

--- a/frontend/app/components/user/DiscordUserDropdown.tsx
+++ b/frontend/app/components/user/DiscordUserDropdown.tsx
@@ -199,7 +199,7 @@ const DiscordUserDropdown: React.FC<Props> = ({
   };
   return (
     <div className="w-full max-w-md">
-      <Combobox value={discordUser} onChange={onSelect}>
+      <Combobox value={discordUser} onChange={(u) => { if (u) onSelect(u); }}>
         <ComboboxInput
           className="input input-bordered w-full"
           placeholder="Search DTX members..."

--- a/frontend/app/components/user/positions/index.tsx
+++ b/frontend/app/components/user/positions/index.tsx
@@ -378,11 +378,7 @@ export const HardSupportBadge: React.FC<BadgeProps> = memo(({ user, compact, dis
   );
 });
 interface RolePositionsProps {
-  /**
-   * The user whose positions to render. Only `pk` and `positions` are read, so
-   * synthetic callers (see the body: org-boolean strips that supply positions
-   * inline and have no cached pk) may pass just `{ positions }`.
-   */
+  /** Only `pk` and `positions` are read, so callers with no cached pk may pass just `{ positions }`. */
   user: UserType | { pk?: number; positions?: UserType['positions'] };
   /**
    * Compact mode: icon + rank only, no text labels.

--- a/frontend/app/components/user/positions/index.tsx
+++ b/frontend/app/components/user/positions/index.tsx
@@ -378,7 +378,12 @@ export const HardSupportBadge: React.FC<BadgeProps> = memo(({ user, compact, dis
   );
 });
 interface RolePositionsProps {
-  user: UserType;
+  /**
+   * The user whose positions to render. Only `pk` and `positions` are read, so
+   * synthetic callers (see the body: org-boolean strips that supply positions
+   * inline and have no cached pk) may pass just `{ positions }`.
+   */
+  user: UserType | { pk?: number; positions?: UserType['positions'] };
   /**
    * Compact mode: icon + rank only, no text labels.
    * - `true`: Always compact

--- a/frontend/app/hooks/usePermissions.ts
+++ b/frontend/app/hooks/usePermissions.ts
@@ -161,6 +161,13 @@ export function useIsOrganizationStaff(
 }
 
 /**
+ * Minimal leagues (a tournament's embedded `LeagueMinimalSchema`) and bare pks
+ * carry no staff/admin arrays, so the league-level checks below skip and only
+ * the `organizations` cascade decides — such call sites must pass the org.
+ */
+export type LeagueLike = Partial<LeagueType> | number | null | undefined;
+
+/**
  * Check if the current user is an admin of the given league.
  * League admin access includes admins of any linked organization.
  *
@@ -168,26 +175,12 @@ export function useIsOrganizationStaff(
  * @param organizations - Array of parent organizations (for org admin check)
  * @returns true if user is league admin, admin of any linked org, or superuser
  */
-/**
- * League argument accepted by the permission hooks.
- *
- * Call sites pass either a full `LeagueType`, the lightweight
- * `LeagueMinimalSchema` embedded on a tournament (pk/name/organization_name —
- * no staff/admin arrays), or a raw pk. Every league field read below is
- * optional-chained, so a minimal league or a bare pk simply skips the
- * league-level checks and falls through to the `organizations` cascade. That
- * is why those call sites fetch the org separately and pass it as the second
- * argument.
- */
-export type LeagueLike = Partial<LeagueType> | number | null | undefined;
-
 export function useIsLeagueAdmin(
   league: LeagueLike,
   organizations?: OrganizationType[] | OrganizationType | null
 ): boolean {
   const currentUser = useUserStore((state) => state.currentUser);
-  // A tournament's `league` can arrive as a bare pk; only the object form
-  // carries the staff/admin arrays these checks read.
+  // Narrow away the bare-pk form; only objects carry staff/admin arrays.
   const leagueObj = typeof league === 'object' ? league : null;
 
   return useMemo(() => {
@@ -258,8 +251,7 @@ export function useIsLeagueStaff(
   organizations?: OrganizationType[] | OrganizationType | null
 ): boolean {
   const currentUser = useUserStore((state) => state.currentUser);
-  // A tournament's `league` can arrive as a bare pk; only the object form
-  // carries the staff/admin arrays these checks read.
+  // Narrow away the bare-pk form; only objects carry staff/admin arrays.
   const leagueObj = typeof league === 'object' ? league : null;
   const isLeagueAdmin = useIsLeagueAdmin(league, organizations);
 

--- a/frontend/app/hooks/usePermissions.ts
+++ b/frontend/app/hooks/usePermissions.ts
@@ -168,11 +168,27 @@ export function useIsOrganizationStaff(
  * @param organizations - Array of parent organizations (for org admin check)
  * @returns true if user is league admin, admin of any linked org, or superuser
  */
+/**
+ * League argument accepted by the permission hooks.
+ *
+ * Call sites pass either a full `LeagueType`, the lightweight
+ * `LeagueMinimalSchema` embedded on a tournament (pk/name/organization_name —
+ * no staff/admin arrays), or a raw pk. Every league field read below is
+ * optional-chained, so a minimal league or a bare pk simply skips the
+ * league-level checks and falls through to the `organizations` cascade. That
+ * is why those call sites fetch the org separately and pass it as the second
+ * argument.
+ */
+export type LeagueLike = Partial<LeagueType> | number | null | undefined;
+
 export function useIsLeagueAdmin(
-  league: LeagueType | null | undefined,
+  league: LeagueLike,
   organizations?: OrganizationType[] | OrganizationType | null
 ): boolean {
   const currentUser = useUserStore((state) => state.currentUser);
+  // A tournament's `league` can arrive as a bare pk; only the object form
+  // carries the staff/admin arrays these checks read.
+  const leagueObj = typeof league === 'object' ? league : null;
 
   return useMemo(() => {
     if (!currentUser?.pk) return false;
@@ -183,9 +199,9 @@ export function useIsLeagueAdmin(
     if (currentUser.is_staff || currentUser.is_superuser) return true;
 
     // League-specific lookups only meaningful when a league is present.
-    if (league) {
-      if (league.admin_ids?.includes(currentUser.pk)) return true;
-      if (league.admins?.some((admin) => admin.pk === currentUser.pk)) {
+    if (leagueObj) {
+      if (leagueObj.admin_ids?.includes(currentUser.pk)) return true;
+      if (leagueObj.admins?.some((admin) => admin.pk === currentUser.pk)) {
         return true;
       }
     }
@@ -197,8 +213,8 @@ export function useIsLeagueAdmin(
       ? organizations
       : organizations
         ? [organizations]
-        : league?.organization
-          ? [league.organization]
+        : leagueObj?.organization
+          ? [leagueObj.organization]
           : [];
 
     for (const org of orgs) {
@@ -224,7 +240,7 @@ export function useIsLeagueAdmin(
     currentUser?.pk,
     currentUser?.is_staff,
     currentUser?.is_superuser,
-    league,
+    leagueObj,
     organizations,
   ]);
 }
@@ -238,10 +254,13 @@ export function useIsLeagueAdmin(
  * @returns true if user is league admin, league staff, org admin, org staff, or superuser
  */
 export function useIsLeagueStaff(
-  league: LeagueType | null | undefined,
+  league: LeagueLike,
   organizations?: OrganizationType[] | OrganizationType | null
 ): boolean {
   const currentUser = useUserStore((state) => state.currentUser);
+  // A tournament's `league` can arrive as a bare pk; only the object form
+  // carries the staff/admin arrays these checks read.
+  const leagueObj = typeof league === 'object' ? league : null;
   const isLeagueAdmin = useIsLeagueAdmin(league, organizations);
 
   return useMemo(() => {
@@ -257,9 +276,9 @@ export function useIsLeagueStaff(
     if (isLeagueAdmin) return true;
 
     // League-specific staff lookups only meaningful when a league is present.
-    if (league) {
-      if (league.staff_ids?.includes(currentUser.pk)) return true;
-      if (league.staff?.some((staff) => staff.pk === currentUser.pk)) {
+    if (leagueObj) {
+      if (leagueObj.staff_ids?.includes(currentUser.pk)) return true;
+      if (leagueObj.staff?.some((staff) => staff.pk === currentUser.pk)) {
         return true;
       }
     }
@@ -271,8 +290,8 @@ export function useIsLeagueStaff(
       ? organizations
       : organizations
         ? [organizations]
-        : league?.organization
-          ? [league.organization]
+        : leagueObj?.organization
+          ? [leagueObj.organization]
           : [];
 
     for (const org of orgs) {
@@ -292,7 +311,7 @@ export function useIsLeagueStaff(
     currentUser?.pk,
     currentUser?.is_staff,
     currentUser?.is_superuser,
-    league,
+    leagueObj,
     isLeagueAdmin,
     organizations,
   ]);
@@ -309,7 +328,7 @@ export function useIsLeagueStaff(
  * @returns true if user can edit tournaments in this league
  */
 export function useCanEditTournament(
-  league: LeagueType | null | undefined,
+  league: LeagueLike,
   organizations?: OrganizationType[] | OrganizationType | null
 ): boolean {
   return useIsLeagueStaff(league, organizations);
@@ -324,7 +343,7 @@ export function useCanEditTournament(
  * @returns true if user can manage games in this league
  */
 export function useCanManageGames(
-  league: LeagueType | null | undefined,
+  league: LeagueLike,
   organizations?: OrganizationType[] | OrganizationType | null
 ): boolean {
   return useIsLeagueStaff(league, organizations);
@@ -364,7 +383,7 @@ export function useCanCreateAnyTournament(): boolean {
  */
 export function usePermissions(
   organization: OrganizationType | null | undefined,
-  league: LeagueType | null | undefined
+  league: LeagueLike
 ) {
   const isSuperuser = useIsSuperuser();
   const isOrgOwner = useIsOrganizationOwner(organization);

--- a/frontend/app/pages/tournament/hasErrors.test.tsx
+++ b/frontend/app/pages/tournament/hasErrors.test.tsx
@@ -6,7 +6,7 @@ import type { OrganizationType } from '~/components/organization/schemas';
 
 describe('deriveEditScope', () => {
   const org: OrganizationType = { pk: 7, name: 'Events Test Org' } as OrganizationType;
-  const league: LeagueType = { pk: 7, name: 'Events Test League', organization: org } as LeagueType;
+  const league: LeagueType = { pk: 7, name: 'Events Test League', organization: org } as unknown as LeagueType;
 
   it('returns league scope when a league is present', () => {
     expect(deriveEditScope({ league, currentOrg: org })).toEqual({

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -93,6 +93,8 @@ import { AddUserModal } from '~/components/user/AddUserModal';
 import { useResolvedUsers } from '~/hooks/useResolvedUsers';
 import { useOrganization } from '~/components/organization';
 import { usePageNav } from '~/hooks/usePageNav';
+import type { UserType } from '~/components/user/types';
+import type { AddMemberPayload } from '~/components/api/api';
 import { useOrgStore } from '~/store/orgStore';
 import { useUserStore } from '~/store/userStore';
 import { isUserEntry } from '~/store/userCacheTypes';
@@ -788,15 +790,34 @@ function SignupsTab({
 
   const signupUserPks = useMemo(() => new Set(signups.map((s) => s.user)), [signups]);
   const entityContext = useMemo(() => ({ orgId }), [orgId]);
-  const handleAddUser = useCallback(async (payload: { user_id: number }) => {
+  const handleAddUser = useCallback(async (payload: AddMemberPayload): Promise<UserType> => {
+    // adminAddSignup takes a site-user pk only, but the modal's Discord tab can
+    // hand back a discord_id with no user_id. Fail loudly rather than posting
+    // user_id: undefined (the modal surfaces the message as a toast).
+    if (payload.user_id == null) {
+      throw new Error('Select a site user — adding a Discord member directly is not supported here yet.');
+    }
     const resp = await adminAddSignup(eventId!, payload.user_id);
     queryClient.invalidateQueries({ queryKey: ['event-signups', eventId] });
     // Backend now adds the user as an OrgUser when admin signs them up; reset
     // the org-users cache so the org page reflects the new membership.
     if (orgId) useOrgStore.getState().clearOrgUsers();
-    return resp;
+    // AddUserModal reads `.pk` off this to track optimistic adds — the signup
+    // itself has no pk, so hand back the user it embeds.
+    const added = resp.user_data;
+    return added
+      ? {
+          ...added,
+          // The signup serializer nulls these; UserType models them as optional.
+          positions: added.positions ?? undefined,
+          avatarUrl: added.avatarUrl ?? undefined,
+        }
+      : { pk: payload.user_id, username: null };
   }, [eventId, orgId, queryClient]);
-  const checkIsAdded = useCallback((user: { pk: number }) => signupUserPks.has(user.pk), [signupUserPks]);
+  const checkIsAdded = useCallback(
+    (user: UserType) => (user.pk != null ? signupUserPks.has(user.pk) : false),
+    [signupUserPks]
+  );
 
   return (
     <div className="space-y-3">

--- a/frontend/app/routes/event.tsx
+++ b/frontend/app/routes/event.tsx
@@ -791,9 +791,8 @@ function SignupsTab({
   const signupUserPks = useMemo(() => new Set(signups.map((s) => s.user)), [signups]);
   const entityContext = useMemo(() => ({ orgId }), [orgId]);
   const handleAddUser = useCallback(async (payload: AddMemberPayload): Promise<UserType> => {
-    // adminAddSignup takes a site-user pk only, but the modal's Discord tab can
-    // hand back a discord_id with no user_id. Fail loudly rather than posting
-    // user_id: undefined (the modal surfaces the message as a toast).
+    // The modal's Discord tab can hand back a discord_id with no user_id, and
+    // adminAddSignup takes a site-user pk only; the throw surfaces as a toast.
     if (payload.user_id == null) {
       throw new Error('Select a site user — adding a Discord member directly is not supported here yet.');
     }

--- a/frontend/app/routes/events.tsx
+++ b/frontend/app/routes/events.tsx
@@ -329,7 +329,7 @@ export default function EventsPage() {
 
   const statesChanged = selectedStates.size !== DEFAULT_STATES.size ||
     [...DEFAULT_STATES].some((s) => !selectedStates.has(s));
-  const hasActiveFilter = debouncedSearch || statesChanged || !!selectedOrgId;
+  const hasActiveFilter = !!debouncedSearch || statesChanged || !!selectedOrgId;
   const activeFilterCount = [
     selectedOrgId ? 1 : 0,
     statesChanged ? 1 : 0,

--- a/frontend/app/routes/league.tsx
+++ b/frontend/app/routes/league.tsx
@@ -81,10 +81,9 @@ export default function LeaguePage() {
   // Set org and league context for child components (e.g. UsersTab)
   useEffect(() => {
     if (league) {
-      // league.organization is LeagueOrganizationSchema — a lightweight
-      // pk/name/logo org with no discord_server_id, so it cannot stand in for
-      // the full OrganizationType the store's consumers read. Load the real
-      // org by pk instead; getOrganization no-ops when it is already current.
+      // league.organization is the lightweight LeagueOrganizationSchema (no
+      // discord_server_id), so it cannot stand in for the full OrganizationType
+      // the store's consumers read; getOrganization no-ops if already current.
       if (league.organization?.pk) {
         void useOrgStore.getState().getOrganization(league.organization.pk);
       } else {

--- a/frontend/app/routes/league.tsx
+++ b/frontend/app/routes/league.tsx
@@ -81,7 +81,15 @@ export default function LeaguePage() {
   // Set org and league context for child components (e.g. UsersTab)
   useEffect(() => {
     if (league) {
-      useOrgStore.getState().setCurrentOrg(league.organization ?? null);
+      // league.organization is LeagueOrganizationSchema — a lightweight
+      // pk/name/logo org with no discord_server_id, so it cannot stand in for
+      // the full OrganizationType the store's consumers read. Load the real
+      // org by pk instead; getOrganization no-ops when it is already current.
+      if (league.organization?.pk) {
+        void useOrgStore.getState().getOrganization(league.organization.pk);
+      } else {
+        useOrgStore.getState().setCurrentOrg(null);
+      }
       useLeagueStore.getState().setCurrentLeague(league);
     }
 

--- a/frontend/app/routes/user.tsx
+++ b/frontend/app/routes/user.tsx
@@ -1,4 +1,5 @@
 import { UserProfilePage } from '~/pages/user/UserProfilePage';
+import { AvatarUrl } from '~/components/user/UserAvatar';
 import { generateMeta } from '~/lib/seo';
 import { fetchUser } from '~/components/api/api';
 import type { Route } from './+types/user';
@@ -30,7 +31,7 @@ export function meta({ data }: Route.MetaArgs) {
     return generateMeta({
       title: displayName,
       description: `${displayName} — Dota 2 player profile on DraftForge`,
-      image: user.avatar_url || undefined,
+      image: AvatarUrl(user),
       url: `/user/${user.pk}`,
     });
   }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,7 +9,7 @@
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["node", "vite/client"],
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "ESNext",
 
     "moduleResolution": "bundler",
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

Takes the frontend typecheck from **57 errors to 0** (33 app-code + 24 in `node_modules`).

This is the debt that three separate PRs cited as a reason not to act ("~57 pre-existing `tsc` errors on main"). The two branches those PRs pointed at — `fix/app-code-tsc-errors` and `fix/pre-existing-tsc-errors` — were 214 and 253 commits behind with no open PR, so nobody was actually fixing them.

**Six of these were masking real defects**, not cosmetic type noise:

| File | Latent defect the type error was hiding |
|---|---|
| `routes/event.tsx` | `handleAddUser` returned the **signup**, which has no `.pk` — so `AddUserModal`'s optimistic "already added" tracking never fired. |
| `routes/event.tsx` | `AddMemberPayload` allows a `discord_id` with no `user_id`, and the Discord tab **is** reachable (`hasDiscordServer={!!eventOrg?.discord_server_id}`). That path posted `user_id: undefined`. |
| `routes/user.tsx` | `meta()` read `user.avatar_url`, which does not exist (the field is `avatarUrl`) — the OG image was always `undefined`. |
| `HeroDraftModal.tsx` | `rollWinnerTeam?.id === myTeam?.id` matched when **both** were `undefined`, rendering the winner-choice UI for a non-captain. |
| `teamTable.tsx` | Hand-rolled truncation checked `length > 10` but cut at `12`, appending an ellipsis to names it had not truncated. |
| `AutoAssignModal` | `ConfirmButton` had no `loadingText` prop, so `loadingText="Applying..."` was silently dropped and the button read "Confirming...". |

## Approach

Root-cause fixes over casts. Only two casts remain, both justified:
- `hasErrors.test.tsx` — a test fixture cast through `unknown`.
- `axios.tsx` — `window` cast through `unknown` to a string-keyed record.

Notable structural fixes:
- **`usePermissions`** — league params were typed `LeagueType`, but call sites legitimately pass `LeagueMinimalSchema` or a bare pk (both `BracketView` and `MatchStatsModal` have comments explaining exactly this). Widened to a documented `LeagueLike` and normalized to the object form. Every field read was already optional-chained, so **behavior is unchanged**.
- **`routes/league.tsx`** — was pushing the lightweight `LeagueOrganizationSchema` org (no `discord_server_id`) into a store whose consumers read `discord_server_id`. Now loads the full org by pk via the store's existing `getOrganization`, which self-guards against redundant fetches. **This is a behavior change** (adds a fetch on league pages) and is the one thing here worth a careful look.
- **`bracketAPI`** — declared `Promise<BracketResponse>` while returning `BracketResponseSchema.parse()` output. `schemas.ts` already documents these as DTOs; declared the DTO. No caller needed changing.
- **`tsconfig`** — `module: ES2022` → `ESNext`, the standard pairing with `moduleResolution: "bundler"`. Clears all 24 `TS2823` import-attribute errors from `dotaconstants`. Typecheck-only: `noEmit` is set and Vite performs the build.

## Rejected approach

Widening `orgStore.currentOrg` to `Partial<OrganizationType>` looked like the obvious fix for the `league.tsx` error. It made things **worse** — 3 errors became 6, because four other call sites legitimately need a full org. Reverted in favour of loading the real org.

## Verification

- `npx tsc --noEmit` → **0 errors** (from 57).
- `npm run build` → succeeds.
- `npm run lint` → clean (note: it is scoped to `app/components/navbar` only).

## Follow-ups (not in this PR)

1. **Add a `typecheck` CI gate.** Nothing currently enforces this, which is how 33 errors accumulated. Now that it is green, a gate is cheap and will keep it that way.
2. **Event admin-signup has no Discord path.** This PR makes it fail loudly; it does not implement it. `adminAddSignup` takes a site-user pk only.
3. **Widen `npm run lint`** beyond `app/components/navbar`.
4. **A comment-cleanup pass** on files this PR touched — the comment reviewer flagged pre-existing narration in `teamTable.tsx`, `axios.tsx`, `DiscordUserDropdown.tsx`, `bracketAPI.tsx`, `HeroDraftModal.tsx`, and `positions/index.tsx`. Left out deliberately to keep this diff reviewable.
