### PR TITLE
fix(ui): stop Destructive/Warning buttons overriding size=sm with the 44px floor

### DIFF
--- a/frontend/app/components/ui/buttons/DestructiveButton.tsx
+++ b/frontend/app/components/ui/buttons/DestructiveButton.tsx
@@ -29,7 +29,11 @@ export interface DestructiveButtonProps
 const DestructiveButton = React.forwardRef<
   HTMLButtonElement,
   DestructiveButtonProps
->(({ loading = false, disabled, children, className, depth = true, hotkey, ...props }, ref) => {
+>(({ loading = false, disabled, children, className, depth = true, hotkey, size, ...props }, ref) => {
+  // min-h-11 is the 44px touch target for dialog footers, but it would override
+  // an explicit size="sm"/"icon" and leave this button taller than the
+  // Primary/Secondary siblings it sits beside in compact action rows.
+  const touchTarget = size === 'sm' || size === 'icon' ? undefined : 'min-h-11';
   // When hotkey is unset, pass a single child so `asChild` callers stay valid
   // (Slot's React.Children.only rejects arrays — see SecondaryButton note).
   const inner = loading ? (
@@ -45,9 +49,10 @@ const DestructiveButton = React.forwardRef<
     <Button
       ref={ref}
       disabled={disabled || loading}
+      size={size}
       className={cn(
         // min-h-11 matches ConfirmButton/CancelButton so footer rows align.
-        'min-h-11',
+        touchTarget,
         depth ? `${buttonLift} ${buttonDisabled} ${brandErrorPrimary} shadow-red-950/40` : brandErrorPrimary,
         hotkey && 'relative',
         className

--- a/frontend/app/components/ui/buttons/WarningButton.tsx
+++ b/frontend/app/components/ui/buttons/WarningButton.tsx
@@ -24,13 +24,18 @@ export interface WarningButtonProps
  * ```
  */
 const WarningButton = React.forwardRef<HTMLButtonElement, WarningButtonProps>(
-  ({ loading = false, disabled, children, className, depth = true, ...props }, ref) => {
+  ({ loading = false, disabled, children, className, depth = true, size, ...props }, ref) => {
+    // min-h-11 is the 44px touch target for dialog footers, but it would override
+    // an explicit size="sm"/"icon" and leave this button taller than the
+    // Primary/Secondary siblings it sits beside in compact action rows.
+    const touchTarget = size === 'sm' || size === 'icon' ? undefined : 'min-h-11';
     return (
       <Button
         ref={ref}
         disabled={disabled || loading}
+        size={size}
         className={cn(
-          'min-h-11',
+          touchTarget,
           depth ? brandButtonVariants.warning : 'bg-orange-500 text-white hover:bg-orange-400',
           className
         )}

--- a/frontend/app/components/ui/buttons/__tests__/button-size-parity.test.tsx
+++ b/frontend/app/components/ui/buttons/__tests__/button-size-parity.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TooltipProvider } from '~/components/ui/tooltip';
+import { DestructiveButton } from '../DestructiveButton';
+import { WarningButton } from '../WarningButton';
+import { PrimaryButton } from '../PrimaryButton';
+import { SecondaryButton } from '../SecondaryButton';
+
+// DestructiveButton/WarningButton hardcoded min-h-11 (the 44px dialog-footer
+// touch target), which overrode an explicit size="sm" and left them taller than
+// the Primary/Secondary buttons beside them in compact action rows — e.g. the
+// series page header, where Delete towered over Edit and Reactivate.
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+describe('button size parity', () => {
+  it('drops the 44px floor when size="sm" is explicit', () => {
+    render(
+      <Wrapper>
+        <DestructiveButton size="sm">Delete</DestructiveButton>
+        <WarningButton size="sm">Warn</WarningButton>
+      </Wrapper>,
+    );
+    expect(screen.getByRole('button', { name: 'Delete' }).className).not.toContain('min-h-11');
+    expect(screen.getByRole('button', { name: 'Warn' }).className).not.toContain('min-h-11');
+  });
+
+  it('applies the h-8 sm height, matching Primary/Secondary siblings', () => {
+    render(
+      <Wrapper>
+        <DestructiveButton size="sm">Delete</DestructiveButton>
+        <PrimaryButton size="sm">Primary</PrimaryButton>
+        <SecondaryButton size="sm">Secondary</SecondaryButton>
+      </Wrapper>,
+    );
+    for (const name of ['Delete', 'Primary', 'Secondary']) {
+      expect(screen.getByRole('button', { name }).className).toContain('h-8');
+    }
+  });
+
+  it('keeps the 44px touch target at the default size', () => {
+    render(
+      <Wrapper>
+        <DestructiveButton>Delete</DestructiveButton>
+        <WarningButton>Warn</WarningButton>
+      </Wrapper>,
+    );
+    expect(screen.getByRole('button', { name: 'Delete' }).className).toContain('min-h-11');
+    expect(screen.getByRole('button', { name: 'Warn' }).className).toContain('min-h-11');
+  });
+});


### PR DESCRIPTION
## Summary

On the series page, **Delete** rendered visibly taller than Unsubscribe / Add one-off event / Reactivate / Edit, even though every button in that row is `size="sm"`.

Cause: `DestructiveButton` and `WarningButton` hardcode `min-h-11` (the 44px dialog-footer touch target). shadcn's `size="sm"` sets `h-8`, but `min-height` wins, so the button rendered at 44px while its `PrimaryButton`/`SecondaryButton` siblings — which have no such floor — sat at 32px.

The rendered class string made it obvious: `... h-8 rounded-md gap-1.5 px-3 ... min-h-11 ...`

## Fix

Apply the 44px floor only when the caller has *not* asked for a compact size. `size="sm"` / `size="icon"` now drop it; default and `lg` keep it, so dialog footers are unchanged.

This is a component-level fix rather than a patch on the series page — **7 files** mix these buttons with `size="sm"`: `DotaProfileCard`, `ClaimCard`, `EventAdminActions`, `rollcall.tsx`, `event.tsx`, `TournamentDetailPage`, `series.tsx`.

## Test plan

New `app/components/ui/buttons/__tests__/button-size-parity.test.tsx` (3 cases), verified red before green:

- **RED** without the fix: `AssertionError: expected 'inline-flex ... h-8 ... min-h-11 ...' not to contain 'min-h-11'`
- `size="sm"` drops the floor on both buttons ✅
- Destructive/Primary/Secondary all carry `h-8` at `size="sm"` ✅
- Default size still carries `min-h-11` — the touch target is preserved where it matters ✅

`npm test -- --run` → **127 passed** (23 files). No new typecheck errors.